### PR TITLE
Add voice command detection (disregard, cancel, clear)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,11 @@
 
 ## Project: voice-claude
 
+## Active Worktree: voice-commands
+This is a worktree branch for implementing voice command keywords.
+Scope: Command detection module, WebSocket integration, client handling.
+Other parallel branches: always-listening-strategy, dockerize, cost-audit, audio-feedback, chat-redesign
+
 A hands-free voice interface for Claude Code. The goal: talk to Claude through Bluetooth earbuds (Pixel Buds) on an Android phone while your hands are busy — like working at a bakery — and have Claude working on code, managing repos, and talking back.
 
 ## Origin

--- a/apps/server/src/voice/commands.ts
+++ b/apps/server/src/voice/commands.ts
@@ -1,0 +1,72 @@
+/**
+ * Voice command detection module.
+ *
+ * Inspects transcription text for trailing keywords that trigger
+ * special actions (e.g. discard the message, clear conversation).
+ * Commands are case-insensitive and matched at the end of the text.
+ */
+
+export type VoiceCommandType = 'disregard' | 'clear'
+
+export interface VoiceCommandResult {
+  /** The command that was detected, or null if no command matched. */
+  command: VoiceCommandType | null
+  /** The transcription text with the command keyword stripped. */
+  text: string
+}
+
+interface CommandDefinition {
+  type: VoiceCommandType
+  /** Keywords that trigger this command (matched at end of text). */
+  keywords: string[]
+}
+
+const COMMANDS: CommandDefinition[] = [
+  {
+    type: 'disregard',
+    keywords: ['disregard', 'never mind', 'nevermind', 'cancel'],
+  },
+  {
+    type: 'clear',
+    keywords: ['clear', 'reset'],
+  },
+]
+
+/**
+ * Check a transcription for a trailing voice command keyword.
+ *
+ * Returns the detected command (if any) and the transcription with
+ * the keyword stripped. Matching is case-insensitive.
+ *
+ * Examples:
+ *   parseCommand("what files are here disregard")
+ *     => { command: "disregard", text: "what files are here" }
+ *
+ *   parseCommand("hello there")
+ *     => { command: null, text: "hello there" }
+ *
+ *   parseCommand("disregard")
+ *     => { command: "disregard", text: "" }
+ */
+export function parseCommand(transcription: string): VoiceCommandResult {
+  const trimmed = transcription.trim()
+  const lower = trimmed.toLowerCase()
+
+  for (const def of COMMANDS) {
+    for (const keyword of def.keywords) {
+      // Check if the entire text is just the command keyword
+      if (lower === keyword) {
+        return { command: def.type, text: '' }
+      }
+
+      // Check if the text ends with the keyword preceded by a space
+      const suffix = ` ${keyword}`
+      if (lower.endsWith(suffix)) {
+        const stripped = trimmed.slice(0, trimmed.length - suffix.length).trim()
+        return { command: def.type, text: stripped }
+      }
+    }
+  }
+
+  return { command: null, text: trimmed }
+}

--- a/apps/server/src/ws/audio.ts
+++ b/apps/server/src/ws/audio.ts
@@ -1,7 +1,8 @@
 import { randomUUID } from 'node:crypto'
 import type { IncomingMessage, Server } from 'node:http'
 import { WebSocketServer, type WebSocket } from 'ws'
-import { chat } from '../voice/claude.js'
+import { chat, clearSession } from '../voice/claude.js'
+import { parseCommand } from '../voice/commands.js'
 import { transcribe } from '../voice/stt.js'
 import { synthesize } from '../voice/tts.js'
 
@@ -150,6 +151,27 @@ async function handleControl(
         send(ws, { type: 'transcription', text: '', error: message })
         break
       }
+
+      // Check for voice commands before sending to Claude
+      const { command, text: cleanedText } = parseCommand(userText)
+
+      if (command === 'disregard') {
+        console.log(`[ws] command    disregard — dropping message`)
+        send(ws, { type: 'transcription', text: userText })
+        send(ws, { type: 'command', command: 'disregard' })
+        break
+      }
+
+      if (command === 'clear') {
+        console.log(`[ws] command    clear — resetting session ${sessionId.slice(0, 8)}`)
+        clearSession(sessionId)
+        send(ws, { type: 'transcription', text: userText })
+        send(ws, { type: 'command', command: 'clear' })
+        break
+      }
+
+      // Use the cleaned text (command keyword stripped) going forward
+      userText = cleanedText
 
       send(ws, { type: 'transcription', text: userText })
 

--- a/apps/web/app/hooks/use-audio-socket.ts
+++ b/apps/web/app/hooks/use-audio-socket.ts
@@ -12,6 +12,7 @@ interface AudioSocketMessage {
   name?: string
   input?: string
   format?: string
+  command?: string
   toolCalls?: Array<{ name: string; input: string; result: string }>
 }
 
@@ -35,6 +36,7 @@ interface AudioSocketState {
   claudeError: string | null
   toolCalls: Array<{ name: string; input: string; result: string }>
   activeTools: string[]
+  commandNotice: string | null
 }
 
 function playAudio(data: ArrayBuffer): Promise<void> {
@@ -74,7 +76,10 @@ export function useAudioSocket(wsUrl: string | null) {
     claudeError: null,
     toolCalls: [],
     activeTools: [],
+    commandNotice: null,
   })
+
+  const commandTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   useEffect(() => {
     if (!wsUrl) return
@@ -219,6 +224,39 @@ export function useAudioSocket(wsUrl: string | null) {
             setState((s) => ({ ...s, phase: 'done' }))
             break
 
+          case 'command': {
+            const label =
+              msg.command === 'disregard'
+                ? 'Message discarded'
+                : msg.command === 'clear'
+                  ? 'Conversation cleared'
+                  : `Command: ${msg.command}`
+            console.log(`[audio] voice command: ${msg.command}`)
+            setState((s) => ({
+              ...s,
+              phase: 'done',
+              commandNotice: label,
+              // Clear conversation state on reset
+              ...(msg.command === 'clear'
+                ? {
+                    transcription: null,
+                    claudeResponse: null,
+                    claudeError: null,
+                    toolCalls: [],
+                  }
+                : {}),
+            }))
+            // Auto-dismiss the notice after 3 seconds
+            if (commandTimerRef.current) {
+              clearTimeout(commandTimerRef.current)
+            }
+            commandTimerRef.current = setTimeout(() => {
+              setState((s) => ({ ...s, commandNotice: null }))
+              commandTimerRef.current = null
+            }, 3000)
+            break
+          }
+
           default:
             console.log(`[audio] ${msg.type}`, msg)
         }
@@ -303,6 +341,7 @@ export function useAudioSocket(wsUrl: string | null) {
       claudeError: null,
       toolCalls: [],
       activeTools: [],
+      commandNotice: null,
     }))
   }, [])
 

--- a/apps/web/app/routes/home.tsx
+++ b/apps/web/app/routes/home.tsx
@@ -129,6 +129,15 @@ export default function Home() {
 
   return (
     <div className="flex min-h-screen flex-col items-center justify-center px-6 py-12">
+      {/* Voice command toast */}
+      {audio.commandNotice && (
+        <div className="fixed top-6 left-1/2 -translate-x-1/2 z-50 animate-fade-in-up">
+          <div className="rounded-lg border border-border bg-card px-4 py-2 shadow-lg text-sm text-muted-foreground">
+            {audio.commandNotice}
+          </div>
+        </div>
+      )}
+
       <div className="max-w-lg w-full space-y-8 animate-fade-in-up">
         <div className="text-center space-y-3">
           <h1 className="text-4xl font-bold tracking-tight text-foreground">


### PR DESCRIPTION
## Summary
- Post-transcription keyword detection that triggers special actions before messages reach Claude
- **disregard** / **cancel** / **never mind** — drops the message, doesn't send to Claude
- **clear** / **reset** — wipes conversation history for the session
- Keywords detected case-insensitively at the end of transcription text, stripped before processing
- Client shows a brief toast notification when a command is executed

## Files changed
- `apps/server/src/voice/commands.ts` — new `parseCommand()` module
- `apps/server/src/ws/audio.ts` — wired between STT and Claude
- `apps/web/app/hooks/use-audio-socket.ts` — handles `command` message type
- `apps/web/app/routes/home.tsx` — toast indicator for commands

## Test plan
- [ ] Say something ending with "disregard" — message should be dropped, toast shows "Message disregarded"
- [ ] Say something ending with "clear" — conversation history resets, toast shows "Conversation cleared"
- [ ] Say something without a keyword — normal flow to Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)