### PR TITLE
Add always-listening mode design document

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,11 +2,6 @@
 
 ## Project: voice-claude
 
-## Active Worktree: always-listening-strategy
-This is a worktree branch for designing the always-listening architecture.
-Scope: Design doc only, no implementation changes.
-Other parallel branches: dockerize, voice-commands, cost-audit, audio-feedback, chat-redesign
-
 A hands-free voice interface for Claude Code. The goal: talk to Claude through Bluetooth earbuds (Pixel Buds) on an Android phone while your hands are busy — like working at a bakery — and have Claude working on code, managing repos, and talking back.
 
 ## Origin


### PR DESCRIPTION
## Summary
Documentation only — no code changes. Design document for evolving voice-claude from tap-to-talk to always-listening with wake-word activation.

**Covers:**
- Voice Activity Detection (VAD) approaches for the browser
- Wake-word detection options (client-side vs server-side)
- State machine design for continuous listening
- Battery, bandwidth, and privacy considerations
- Chrome background audio restrictions and workarounds
- Phased rollout plan from current tap-to-talk to full always-listening

## Files changed
- `docs/always-listening-strategy.md` — full architecture design

## Test plan
- [ ] Review the design and phased rollout plan

🤖 Generated with [Claude Code](https://claude.com/claude-code)