### PR TITLE
Add Google Cloud TTS migration design doc

### DIFF
--- a/docs/google-cloud-tts-migration.md
+++ b/docs/google-cloud-tts-migration.md
@@ -1,8 +1,283 @@
-# Google Cloud TTS Migration Plan
+# Adding Google Cloud TTS as a Provider
 
 ## Overview
 
-This document outlines the plan for migrating voice-claude's text-to-speech from OpenAI TTS (`tts-1`) to Google Cloud Text-to-Speech. The primary motivation is cost: Google Cloud TTS Standard voices cost $4/1M characters vs OpenAI's $15/1M characters, a 73% reduction. Since TTS accounts for 50-60% of per-interaction cost, this is the single highest-impact cost optimization available.
+This document outlines the plan for adding Google Cloud Text-to-Speech as a TTS provider alongside the existing OpenAI TTS implementation. The design uses a **provider/factory pattern** so that TTS providers are plug-and-play: OpenAI TTS remains the default and continues working exactly as it does today, while Google Cloud TTS (and any future providers) can be selected via an environment variable.
+
+The motivation for adding Google Cloud TTS is cost: Google Standard voices cost $4/1M characters vs OpenAI's $15/1M characters, a 73% reduction. Since TTS accounts for 50-60% of per-interaction cost, this is the single highest-impact cost optimization available.
+
+## Design Principle: Provider Factory Pattern
+
+The core architectural decision is that **no TTS provider is hardcoded**. All providers implement a shared `TTSProvider` interface, and a factory function selects the active provider at runtime based on configuration. This means:
+
+- **OpenAI TTS stays.** It is the current default and remains the default after this work.
+- **Google Cloud TTS is added alongside it.** Setting `TTS_PROVIDER=google` opts in.
+- **Future providers** (ElevenLabs, Azure, local Piper, etc.) can be added by implementing the same interface and registering in the factory. No changes to calling code required.
+
+## TTSProvider Interface (The Centerpiece)
+
+This interface is the contract that every TTS provider must implement. It lives at `apps/server/src/voice/tts-provider.ts`:
+
+```typescript
+/**
+ * Common options for TTS synthesis. Each provider may support additional
+ * provider-specific options, but all must accept these.
+ */
+export interface TTSOptions {
+  /** Provider-specific voice identifier (e.g., "alloy" for OpenAI, "en-US-Standard-C" for Google) */
+  voice?: string
+  /** Output audio format */
+  format?: 'mp3' | 'ogg_opus'
+  /** Speaking rate multiplier (1.0 = normal speed) */
+  speakingRate?: number
+}
+
+/**
+ * The interface every TTS provider must implement.
+ *
+ * This is the plug-and-play contract. Any new provider (ElevenLabs, Azure,
+ * local Piper, etc.) just needs to implement this interface and register
+ * itself in the factory.
+ */
+export interface TTSProvider {
+  /** Human-readable name for logging and debugging */
+  readonly name: string
+
+  /**
+   * Synthesize text into audio.
+   * Returns a Buffer containing audio data in the format specified by options
+   * (or the provider's default format).
+   */
+  synthesize(text: string, options?: TTSOptions): Promise<Buffer>
+
+  /**
+   * The default audio format this provider returns when none is specified.
+   * The client uses this to know how to decode the audio.
+   */
+  readonly defaultFormat: 'mp3' | 'ogg_opus'
+}
+```
+
+Every provider implements this interface. The calling code never references OpenAI or Google directly -- it only talks to `TTSProvider`.
+
+## OpenAI TTS Provider (Wrapping Existing Code)
+
+The current OpenAI TTS logic gets wrapped into a class that implements `TTSProvider`. This is a refactor of the existing code, not a rewrite. The behavior stays identical.
+
+File: `apps/server/src/voice/openai-tts.ts`
+
+```typescript
+import OpenAI from 'openai'
+import type { TTSOptions, TTSProvider } from './tts-provider.js'
+
+export class OpenAITTSProvider implements TTSProvider {
+  readonly name = 'openai'
+  readonly defaultFormat = 'mp3' as const
+
+  private client: OpenAI
+
+  constructor() {
+    this.client = new OpenAI({
+      apiKey: process.env.OPENAI_API_KEY,
+    })
+  }
+
+  async synthesize(text: string, options?: TTSOptions): Promise<Buffer> {
+    const voice = options?.voice ?? process.env.OPENAI_TTS_VOICE ?? 'alloy'
+    const speed = options?.speakingRate ?? 1.0
+
+    const response = await this.client.audio.speech.create({
+      model: 'tts-1',
+      voice: voice as 'alloy' | 'echo' | 'fable' | 'onyx' | 'nova' | 'shimmer',
+      input: text,
+      response_format: 'mp3',
+      speed,
+    })
+
+    const arrayBuffer = await response.arrayBuffer()
+    return Buffer.from(arrayBuffer)
+  }
+}
+```
+
+This is a straight extraction of the existing OpenAI TTS code into the provider interface. Nothing changes about how it works.
+
+## Google Cloud TTS Provider (New)
+
+File: `apps/server/src/voice/google-tts.ts`
+
+```typescript
+import textToSpeech from '@google-cloud/text-to-speech'
+import type { TTSOptions, TTSProvider } from './tts-provider.js'
+
+export class GoogleTTSProvider implements TTSProvider {
+  readonly name = 'google'
+  readonly defaultFormat = 'ogg_opus' as const
+
+  private client: textToSpeech.TextToSpeechClient
+
+  constructor() {
+    // Support both file-based and inline JSON credentials
+    const credentialsJson = process.env.GOOGLE_TTS_CREDENTIALS
+    if (credentialsJson) {
+      const credentials = JSON.parse(credentialsJson)
+      this.client = new textToSpeech.TextToSpeechClient({ credentials })
+    } else {
+      // Falls back to GOOGLE_APPLICATION_CREDENTIALS env var (file path)
+      this.client = new textToSpeech.TextToSpeechClient()
+    }
+  }
+
+  async synthesize(text: string, options?: TTSOptions): Promise<Buffer> {
+    const voice = options?.voice ?? process.env.GOOGLE_TTS_VOICE ?? 'en-US-Standard-C'
+    const speakingRate = options?.speakingRate
+      ?? Number.parseFloat(process.env.GOOGLE_TTS_SPEAKING_RATE ?? '1.0')
+    const format = options?.format ?? this.defaultFormat
+
+    const audioEncoding = format === 'mp3' ? 'MP3' : 'OGG_OPUS'
+
+    const [response] = await this.client.synthesizeSpeech({
+      input: { text },
+      voice: {
+        languageCode: 'en-US',
+        name: voice,
+      },
+      audioConfig: {
+        audioEncoding: audioEncoding as 'MP3' | 'OGG_OPUS',
+        speakingRate,
+      },
+    })
+
+    return Buffer.from(response.audioContent as Uint8Array)
+  }
+}
+```
+
+## Provider Factory (Selects the Active Provider)
+
+This is the entry point that the rest of the application uses. It reads `TTS_PROVIDER` from the environment and returns the right implementation. **The default is `openai`.**
+
+File: `apps/server/src/voice/tts.ts`
+
+```typescript
+import type { TTSProvider } from './tts-provider.js'
+
+/** Registry of known provider constructors, keyed by TTS_PROVIDER value */
+const PROVIDERS: Record<string, () => Promise<TTSProvider>> = {
+  openai: async () => {
+    const { OpenAITTSProvider } = await import('./openai-tts.js')
+    return new OpenAITTSProvider()
+  },
+  google: async () => {
+    const { GoogleTTSProvider } = await import('./google-tts.js')
+    return new GoogleTTSProvider()
+  },
+  // Future providers go here:
+  // elevenlabs: async () => { ... },
+  // azure: async () => { ... },
+  // piper: async () => { ... },
+}
+
+let cachedProvider: TTSProvider | null = null
+
+/**
+ * Get the configured TTS provider.
+ *
+ * Reads TTS_PROVIDER from env (default: "openai") and returns the
+ * corresponding provider instance. The instance is cached for the
+ * lifetime of the process.
+ *
+ * Supported values: "openai" (default), "google"
+ */
+export async function getTTSProvider(): Promise<TTSProvider> {
+  if (!cachedProvider) {
+    const name = process.env.TTS_PROVIDER ?? 'openai'
+    const factory = PROVIDERS[name]
+    if (!factory) {
+      throw new Error(
+        `Unknown TTS provider: "${name}". Supported: ${Object.keys(PROVIDERS).join(', ')}`
+      )
+    }
+    cachedProvider = await factory()
+    console.log(`TTS provider initialized: ${cachedProvider.name}`)
+  }
+  return cachedProvider
+}
+
+/**
+ * Backward-compatible synthesize function.
+ *
+ * Existing code that calls synthesize() continues to work without any
+ * changes. Under the hood it delegates to whatever provider is configured.
+ */
+export async function synthesize(text: string): Promise<Buffer> {
+  const provider = await getTTSProvider()
+  return provider.synthesize(text)
+}
+
+/**
+ * Get the default audio format for the active provider.
+ * The client needs this to know how to decode the audio.
+ */
+export async function getAudioFormat(): Promise<'mp3' | 'ogg_opus'> {
+  const provider = await getTTSProvider()
+  return provider.defaultFormat
+}
+```
+
+### How it works at runtime
+
+1. Application starts. Nothing is loaded yet.
+2. First call to `synthesize()` or `getTTSProvider()` reads `TTS_PROVIDER` from env.
+3. If unset or `"openai"` (the default), it dynamically imports `openai-tts.js` and creates an `OpenAITTSProvider`. Google SDK is never loaded.
+4. If `"google"`, it dynamically imports `google-tts.js` and creates a `GoogleTTSProvider`. OpenAI SDK is never loaded for TTS.
+5. The provider instance is cached. All subsequent calls reuse it.
+
+### Adding a new provider in the future
+
+To add, say, ElevenLabs:
+
+1. Create `apps/server/src/voice/elevenlabs-tts.ts` implementing `TTSProvider`
+2. Add one entry to the `PROVIDERS` map in `tts.ts`:
+   ```typescript
+   elevenlabs: async () => {
+     const { ElevenLabsTTSProvider } = await import('./elevenlabs-tts.js')
+     return new ElevenLabsTTSProvider()
+   },
+   ```
+3. Set `TTS_PROVIDER=elevenlabs` in env. Done.
+
+No other code changes needed. The factory handles it.
+
+## File Layout
+
+```
+apps/server/src/voice/
+  tts-provider.ts     -- TTSProvider interface + TTSOptions type
+  tts.ts              -- Factory function + backward-compatible synthesize()
+  openai-tts.ts       -- OpenAITTSProvider (wraps existing code)
+  google-tts.ts       -- GoogleTTSProvider (new)
+```
+
+## Environment Variables
+
+```env
+# TTS provider selection (default: "openai")
+# Supported values: "openai", "google"
+TTS_PROVIDER=openai
+
+# --- OpenAI TTS config (used when TTS_PROVIDER=openai) ---
+OPENAI_API_KEY=sk-...             # Already exists; also used for Whisper STT
+OPENAI_TTS_VOICE=alloy            # alloy, echo, fable, onyx, nova, shimmer
+
+# --- Google Cloud TTS config (used when TTS_PROVIDER=google) ---
+GOOGLE_APPLICATION_CREDENTIALS=   # Path to service account JSON key file
+GOOGLE_TTS_CREDENTIALS=           # OR: inline JSON string (for Docker)
+GOOGLE_TTS_VOICE=en-US-Standard-C # Voice name
+GOOGLE_TTS_SPEAKING_RATE=1.0      # 0.25 to 4.0
+```
+
+**The default is `openai`.** If `TTS_PROVIDER` is not set, OpenAI TTS is used. This is a non-breaking change: existing deployments that have no `TTS_PROVIDER` set will behave identically to today.
 
 ## Google Cloud TTS API: Voice Tiers
 
@@ -47,7 +322,7 @@ Google Cloud TTS offers three tiers of voices, each with different quality and p
 
 For our use case (spoken code discussions through Bluetooth earbuds in a potentially noisy environment like a bakery), Standard voice quality should be sufficient. The content comprehension matters far more than vocal aesthetics.
 
-## Authentication Setup
+## Google Cloud Authentication Setup
 
 ### Service Account Creation
 1. Create a GCP project (or use an existing one)
@@ -70,17 +345,6 @@ GOOGLE_TTS_CREDENTIALS='{"type":"service_account","project_id":"...","private_ke
 
 For our Docker setup, Option B is preferred since it avoids mounting a credentials file. The server would parse the JSON string and pass it to the SDK client constructor.
 
-### Environment Variables to Add
-```env
-# TTS provider selection
-TTS_PROVIDER=google          # "openai" | "google" (default: "openai" for backward compat)
-
-# Google Cloud TTS config
-GOOGLE_APPLICATION_CREDENTIALS=  # path to service account JSON key
-GOOGLE_TTS_VOICE=en-US-Standard-C  # voice name
-GOOGLE_TTS_SPEAKING_RATE=1.0       # 0.25 to 4.0
-```
-
 ## SDK: @google-cloud/text-to-speech
 
 The official npm package is `@google-cloud/text-to-speech`.
@@ -90,119 +354,30 @@ The official npm package is `@google-cloud/text-to-speech`.
 pnpm add @google-cloud/text-to-speech --filter @voice-claude/server
 ```
 
-### Basic Usage
-```typescript
-import textToSpeech from '@google-cloud/text-to-speech'
-
-const client = new textToSpeech.TextToSpeechClient()
-
-const [response] = await client.synthesizeSpeech({
-  input: { text: 'Hello from Google Cloud TTS' },
-  voice: {
-    languageCode: 'en-US',
-    name: 'en-US-Standard-C',
-  },
-  audioConfig: {
-    audioEncoding: 'OGG_OPUS',  // or 'MP3'
-    speakingRate: 1.0,
-  },
-})
-
-// response.audioContent is a Buffer
-```
-
 ### SSML Support (Future Enhancement)
 Google TTS supports SSML, which could be useful for:
 - Adding pauses between code blocks and explanations
 - Spelling out variable names letter-by-letter when needed
 - Controlling emphasis on important words
 
-This is not needed for the initial migration but is a nice capability to have available.
-
-## Implementation Plan
-
-### Step 1: Define a TTS Provider Interface
-
-Create `apps/server/src/voice/tts-provider.ts`:
-
-```typescript
-export interface TTSProvider {
-  synthesize(text: string, options?: TTSOptions): Promise<Buffer>
-}
-
-export interface TTSOptions {
-  voice?: string
-  format?: 'mp3' | 'ogg_opus'
-  speakingRate?: number
-}
-```
-
-### Step 2: Wrap Existing OpenAI TTS
-
-Refactor `apps/server/src/voice/tts.ts` into `apps/server/src/voice/openai-tts.ts` implementing the `TTSProvider` interface. This preserves the current behavior exactly.
-
-### Step 3: Implement Google Cloud TTS Provider
-
-Create `apps/server/src/voice/google-tts.ts` implementing `TTSProvider` using `@google-cloud/text-to-speech`.
-
-### Step 4: Create Provider Factory
-
-Update `apps/server/src/voice/tts.ts` to export a factory that reads `TTS_PROVIDER` from env and returns the appropriate provider:
-
-```typescript
-import type { TTSProvider } from './tts-provider.js'
-
-let provider: TTSProvider | null = null
-
-export function getTTSProvider(): TTSProvider {
-  if (!provider) {
-    const name = process.env.TTS_PROVIDER ?? 'openai'
-    if (name === 'google') {
-      // dynamic import to avoid loading SDK when not needed
-      const { GoogleTTSProvider } = require('./google-tts.js')
-      provider = new GoogleTTSProvider()
-    } else {
-      const { OpenAITTSProvider } = require('./openai-tts.js')
-      provider = new OpenAITTSProvider()
-    }
-  }
-  return provider
-}
-
-// Keep backward-compatible export
-export async function synthesize(text: string): Promise<Buffer> {
-  return getTTSProvider().synthesize(text)
-}
-```
-
-### Step 5: Update Callers
-
-Any code that imports `synthesize` from `./voice/tts.js` should continue to work without changes since we maintain the same export signature.
-
-### Step 6: Update Configuration
-
-- Add new env vars to `.env.example`
-- Update `docker-compose.yml` and `docker-compose.prod.yml` to pass through the new env vars
-- Update the CLAUDE.md environment variables table
+This is not needed for the initial implementation but is a nice capability to have available.
 
 ## Audio Format Considerations
 
-### MP3 (current)
+### MP3 (OpenAI default)
 - Universal browser support
 - Higher bandwidth (~32kbps at low quality, ~128kbps typical)
 - Higher encoding overhead
 - What we use today with OpenAI
 
-### OGG/Opus (recommended for Google TTS)
+### OGG/Opus (Google default)
 - Excellent browser support (all modern browsers)
 - Much lower bandwidth (~16-24kbps for speech with similar quality)
 - Lower latency encoding
 - Native WebSocket-friendly format
 - Google TTS supports it natively (no server-side transcoding)
 
-**Recommendation:** Use OGG/Opus with Google TTS. It reduces bandwidth by roughly 50% compared to MP3, which matters for mobile connections. The web client's `AudioContext` API handles Opus decoding natively. Keep MP3 as the format for OpenAI TTS since that is what their API returns most efficiently.
-
-This means the `TTSOptions.format` field matters: the provider factory should default to `ogg_opus` for Google and `mp3` for OpenAI, and the client playback code needs to handle both formats (which it effectively already does via the browser's built-in audio decoding).
+**Each provider uses its optimal format by default.** OpenAI returns MP3; Google returns OGG/Opus. The `TTSProvider.defaultFormat` property tells the client which format to expect, so the playback code can handle both transparently (which it effectively already does via the browser's built-in audio decoding).
 
 ## Latency Comparison
 
@@ -221,19 +396,23 @@ Google Standard voices should be faster because:
 
 This is a meaningful improvement given our target of keeping the full STT + Claude + TTS loop under 3-4 seconds.
 
-## Migration Steps
+## Implementation Phases
 
-### Phase 1: Abstraction (no behavior change)
-1. Create `TTSProvider` interface
-2. Refactor current OpenAI code into `OpenAITTSProvider` class
-3. Create factory in `tts.ts` that defaults to OpenAI
-4. Verify all existing tests pass, no behavior change
+### Phase 1: Abstraction Layer (no behavior change)
+1. Create `TTSProvider` interface and `TTSOptions` type in `tts-provider.ts`
+2. Create `OpenAITTSProvider` class wrapping the existing OpenAI TTS code
+3. Create the provider factory in `tts.ts` with the `PROVIDERS` registry
+4. Wire up the backward-compatible `synthesize()` export
+5. Verify all existing tests pass -- behavior is identical, only the internal structure changed
 
-### Phase 2: Google TTS Implementation
-1. Add `@google-cloud/text-to-speech` dependency
-2. Implement `GoogleTTSProvider`
-3. Add Google-specific env vars to `.env.example`
-4. Write unit tests for the Google provider (mock the SDK)
+After Phase 1, the app still uses OpenAI TTS exactly as before. The factory defaults to `openai`. No new dependencies. This phase is safe to merge on its own.
+
+### Phase 2: Add Google Cloud TTS Provider
+1. Install `@google-cloud/text-to-speech` dependency
+2. Implement `GoogleTTSProvider` class
+3. Register `google` in the `PROVIDERS` map
+4. Add Google-specific env vars to `.env.example`
+5. Write unit tests for the Google provider (mock the SDK)
 
 ### Phase 3: Integration Testing
 1. Set up a GCP project with TTS API enabled
@@ -243,9 +422,9 @@ This is a meaningful improvement given our target of keeping the full STT + Clau
 5. Test in Docker environment with credential passthrough
 
 ### Phase 4: Rollout
-1. Default remains `TTS_PROVIDER=openai`
-2. Document the switch in README/CLAUDE.md
-3. After validation period, consider switching the default to `google`
+1. **Default remains `TTS_PROVIDER=openai`.** Nothing changes for existing users.
+2. Document the `TTS_PROVIDER=google` option in README/CLAUDE.md
+3. After a validation period, consider whether to switch the default to `google`
 
 ### Recommended Google Voices to Evaluate
 - `en-US-Standard-C` (female) -- generally the most natural Standard voice


### PR DESCRIPTION
## Summary
Design doc for switching TTS from OpenAI ($15/1M chars) to Google Cloud TTS Standard ($4/1M chars) — a 73% cost reduction on our biggest spend category.

Covers voice tiers, quality comparison, auth setup, SDK options, implementation plan (provider interface + factory), audio format considerations (OGG/Opus), latency comparison, and phased migration.

## Files changed
- `docs/google-cloud-tts-migration.md` — design doc (no code changes)

## Test plan
- [ ] Review design and migration plan

🤖 Generated with [Claude Code](https://claude.com/claude-code)