### PR TITLE
Add Anthropic prompt caching for system prompt and tools

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,10 +2,6 @@
 
 ## Project: voice-claude
 
-## Active Worktree: prompt-caching
-Scope: Add Anthropic prompt caching for system prompt and tool definitions.
-Other parallel branches: concise-prompting, selective-tts, google-cloud-tts, smart-model-routing, local-whisper-design, local-tts-design, cost-monitoring
-
 A hands-free voice interface for Claude Code. The goal: talk to Claude through Bluetooth earbuds (Pixel Buds) on an Android phone while your hands are busy — like working at a bakery — and have Claude working on code, managing repos, and talking back.
 
 ## Origin


### PR DESCRIPTION
## Summary
Enables Anthropic prompt caching on the system prompt, reducing input token costs by up to 90% for the cached portion in multi-turn conversations.

- System prompt passed as content block array with `cache_control: { type: "ephemeral" }`
- This caches both system prompt and tool definitions (tools render before system in the cache prefix)
- Logs cache hit/miss stats (`cache_read_input_tokens`, `cache_creation_input_tokens`) when non-zero

## Files changed
- `apps/server/src/voice/claude.ts` — system prompt format + cache logging

## Test plan
- [ ] First request in a session should show `cache_creation_input_tokens` in server logs
- [ ] Subsequent requests should show `cache_read_input_tokens` (cache hit)
- [ ] Responses should be unchanged in quality

🤖 Generated with [Claude Code](https://claude.com/claude-code)