### PR TITLE
Implement STT provider factory with local Whisper support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,5 +15,14 @@ OPENAI_API_KEY=sk-...
 # auto = Haiku for simple queries, Sonnet for tool-heavy ones
 # CLAUDE_MODEL=auto
 
+# STT provider: openai | local (default: openai)
+# STT_PROVIDER=openai
+
+# Local Whisper settings (only used when STT_PROVIDER=local)
+# Path to whisper.cpp model file (required for local provider)
+# WHISPER_MODEL_PATH=/models/ggml-base.en.bin
+# Path to whisper-cpp binary (default: whisper-cpp)
+# WHISPER_BINARY=whisper-cpp
+
 # Working directory for Claude tool execution (defaults to cwd)
 # WORK_DIR=/path/to/your/projects

--- a/apps/server/src/voice/local-stt.ts
+++ b/apps/server/src/voice/local-stt.ts
@@ -1,0 +1,109 @@
+import { execFile } from 'node:child_process'
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { promisify } from 'node:util'
+import type { STTProvider, STTResult } from './stt-provider.js'
+
+const execFileAsync = promisify(execFile)
+
+export class LocalSTTProvider implements STTProvider {
+  readonly name = 'local'
+  private readonly binaryPath: string
+  private readonly modelPath: string
+
+  constructor() {
+    this.binaryPath = process.env.WHISPER_BINARY ?? 'whisper-cpp'
+    this.modelPath = process.env.WHISPER_MODEL_PATH ?? ''
+
+    if (!this.modelPath) {
+      throw new Error(
+        'WHISPER_MODEL_PATH environment variable is required when using the local STT provider',
+      )
+    }
+  }
+
+  async transcribe(audioBuffer: Buffer, mimeType = 'audio/webm'): Promise<STTResult> {
+    const tempDir = await mkdtemp(join(tmpdir(), 'stt-'))
+    const inputPath = join(tempDir, 'input.webm')
+    const wavPath = join(tempDir, 'input.wav')
+
+    try {
+      console.log(
+        `[stt:local] transcribing ${(audioBuffer.byteLength / 1024).toFixed(1)} KB of ${mimeType}`,
+      )
+      const start = Date.now()
+
+      // Write the incoming audio to a temp file
+      await writeFile(inputPath, audioBuffer)
+
+      // Convert to 16kHz mono WAV via ffmpeg
+      await execFileAsync('ffmpeg', [
+        '-i',
+        inputPath,
+        '-ar',
+        '16000',
+        '-ac',
+        '1',
+        '-f',
+        'wav',
+        wavPath,
+      ])
+
+      // Run whisper-cpp on the WAV file
+      const { stdout } = await execFileAsync(this.binaryPath, [
+        '-m',
+        this.modelPath,
+        '-f',
+        wavPath,
+        '--language',
+        'en',
+        '--no-timestamps',
+        '--output-json',
+      ])
+
+      const elapsed = Date.now() - start
+
+      // Parse the whisper-cpp output
+      const { text, durationSec } = this.parseOutput(stdout)
+
+      console.log(
+        `[stt:local] result (${elapsed}ms, ${durationSec.toFixed(1)}s audio): "${text}"`,
+      )
+      return { text, durationSec }
+    } finally {
+      // Clean up temp files
+      await rm(tempDir, { recursive: true, force: true }).catch(() => {})
+    }
+  }
+
+  private parseOutput(stdout: string): { text: string; durationSec: number } {
+    let text = ''
+    let durationSec = 0
+
+    try {
+      // Try parsing stdout as JSON (whisper-cpp --output-json may write to stdout)
+      const json = JSON.parse(stdout)
+      if (json.transcription) {
+        text = json.transcription
+          .map((segment: { text: string }) => segment.text)
+          .join('')
+          .trim()
+      } else if (json.text) {
+        text = json.text.trim()
+      }
+      if (json.result?.duration) {
+        durationSec = json.result.duration
+      }
+    } catch {
+      // Fall back to parsing plain text output from stdout
+      // whisper-cpp plain output: "[00:00:00.000 --> 00:00:05.000]  Hello world"
+      // With --no-timestamps it outputs just the text
+      text = stdout
+        .replace(/\[[\d:.]+\s*-->\s*[\d:.]+\]\s*/g, '')
+        .trim()
+    }
+
+    return { text, durationSec }
+  }
+}

--- a/apps/server/src/voice/openai-stt.ts
+++ b/apps/server/src/voice/openai-stt.ts
@@ -1,0 +1,33 @@
+import { toFile } from 'openai'
+import { getOpenAIClient } from './openai.js'
+import type { STTProvider, STTResult } from './stt-provider.js'
+
+export class OpenAISTTProvider implements STTProvider {
+  readonly name = 'openai'
+
+  async transcribe(audioBuffer: Buffer, mimeType = 'audio/webm'): Promise<STTResult> {
+    const openai = getOpenAIClient()
+
+    const ext = mimeType.includes('webm') ? 'webm' : 'wav'
+    const file = await toFile(audioBuffer, `audio.${ext}`, { type: mimeType })
+
+    console.log(
+      `[stt:openai] transcribing ${(audioBuffer.byteLength / 1024).toFixed(1)} KB of ${mimeType}`,
+    )
+    const start = Date.now()
+
+    const response = await openai.audio.transcriptions.create({
+      model: 'whisper-1',
+      file,
+      response_format: 'verbose_json',
+    })
+
+    const elapsed = Date.now() - start
+    const resp = response as unknown as { text?: string; duration?: number }
+    const text = (resp.text ?? '').trim()
+    const durationSec = resp.duration ?? 0
+
+    console.log(`[stt:openai] result (${elapsed}ms, ${durationSec.toFixed(1)}s audio): "${text}"`)
+    return { text, durationSec }
+  }
+}

--- a/apps/server/src/voice/stt-provider.ts
+++ b/apps/server/src/voice/stt-provider.ts
@@ -1,0 +1,9 @@
+export interface STTResult {
+  text: string
+  durationSec: number
+}
+
+export interface STTProvider {
+  readonly name: string
+  transcribe(audioBuffer: Buffer, mimeType?: string): Promise<STTResult>
+}

--- a/apps/server/src/voice/stt.ts
+++ b/apps/server/src/voice/stt.ts
@@ -1,36 +1,46 @@
-import { toFile } from 'openai'
-import { getOpenAIClient } from './openai.js'
+import { LocalSTTProvider } from './local-stt.js'
+import { OpenAISTTProvider } from './openai-stt.js'
+import type { STTProvider, STTResult } from './stt-provider.js'
 
-export interface TranscriptionResult {
-  text: string
-  durationSec: number
+export type { STTProvider, STTResult }
+export type { STTResult as TranscriptionResult }
+
+// Provider registry: maps provider name to a lazy factory
+const providers: Record<string, () => STTProvider> = {
+  openai: () => new OpenAISTTProvider(),
+  local: () => new LocalSTTProvider(),
 }
 
+let cachedProvider: STTProvider | null = null
+
+/**
+ * Returns the configured STT provider.
+ * Reads STT_PROVIDER env var (default: "openai").
+ */
+export function getSTTProvider(): STTProvider {
+  if (cachedProvider) return cachedProvider
+
+  const name = process.env.STT_PROVIDER ?? 'openai'
+  const factory = providers[name]
+
+  if (!factory) {
+    const available = Object.keys(providers).join(', ')
+    throw new Error(`Unknown STT_PROVIDER "${name}". Available providers: ${available}`)
+  }
+
+  cachedProvider = factory()
+  console.log(`[stt] using provider: ${cachedProvider.name}`)
+  return cachedProvider
+}
+
+/**
+ * Backward-compatible transcribe function.
+ * Delegates to the configured STT provider.
+ */
 export async function transcribe(
   audioBuffer: Buffer,
   mimeType = 'audio/webm',
-): Promise<TranscriptionResult> {
-  const openai = getOpenAIClient()
-
-  const ext = mimeType.includes('webm') ? 'webm' : 'wav'
-  const file = await toFile(audioBuffer, `audio.${ext}`, { type: mimeType })
-
-  console.log(
-    `[stt] transcribing ${(audioBuffer.byteLength / 1024).toFixed(1)} KB of ${mimeType}`,
-  )
-  const start = Date.now()
-
-  const response = await openai.audio.transcriptions.create({
-    model: 'whisper-1',
-    file,
-    response_format: 'verbose_json',
-  })
-
-  const elapsed = Date.now() - start
-  const resp = response as unknown as { text?: string; duration?: number }
-  const text = (resp.text ?? '').trim()
-  const durationSec = resp.duration ?? 0
-
-  console.log(`[stt] result (${elapsed}ms, ${durationSec.toFixed(1)}s audio): "${text}"`)
-  return { text, durationSec }
+): Promise<STTResult> {
+  const provider = getSTTProvider()
+  return provider.transcribe(audioBuffer, mimeType)
 }


### PR DESCRIPTION
## Summary
Mirrors the TTS factory pattern for STT. Establishes `STTProvider` interface, wraps existing OpenAI Whisper, adds local whisper-cpp provider.

- **`stt-provider.ts`** — `STTProvider` interface + `STTResult`
- **`openai-stt.ts`** — `OpenAISTTProvider` wrapping existing Whisper API code
- **`local-stt.ts`** — `LocalSTTProvider`: webm→wav via ffmpeg, then whisper-cpp
- **`stt.ts`** — Factory with `getSTTProvider()`, backward-compatible `transcribe()`
- `STT_PROVIDER=openai` (default) or `STT_PROVIDER=local`

## Test plan
- [ ] Default — uses OpenAI Whisper, works as before
- [ ] `STT_PROVIDER=local` with whisper-cpp + model installed — transcribes locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)