### PR TITLE
Implement always-listening Phase 1: VAD with auto-send

### DIFF
--- a/apps/web/app/components/mic-button.tsx
+++ b/apps/web/app/components/mic-button.tsx
@@ -2,8 +2,10 @@ interface MicButtonProps {
   phase: string
   connected: boolean
   busy: boolean
+  mode: 'push-to-talk' | 'auto'
   onStart: () => void
   onStop: () => void
+  onToggleMode: () => void
 }
 
 function MicIcon({ className }: { className?: string }) {
@@ -42,55 +44,82 @@ function StopIcon({ className }: { className?: string }) {
   )
 }
 
-const PHASE_HINTS: Record<string, string> = {
-  idle: 'Tap or hold space',
-  recording: 'Release to send',
-  transcribing: 'Transcribing...',
-  thinking: 'Thinking...',
-  synthesizing: 'Generating...',
-  speaking: 'Speaking...',
-  done: 'Tap or hold space',
+const PHASE_HINTS: Record<string, Record<string, string>> = {
+  'push-to-talk': {
+    idle: 'Tap or hold space',
+    recording: 'Release to send',
+    transcribing: 'Transcribing...',
+    thinking: 'Thinking...',
+    synthesizing: 'Generating...',
+    speaking: 'Speaking...',
+    done: 'Tap or hold space',
+  },
+  auto: {
+    idle: 'Listening...',
+    recording: 'Speak now...',
+    transcribing: 'Transcribing...',
+    thinking: 'Thinking...',
+    synthesizing: 'Generating...',
+    speaking: 'Speaking...',
+    done: 'Listening...',
+  },
 }
 
 export function MicButton({
   phase,
   connected,
   busy,
+  mode,
   onStart,
   onStop,
+  onToggleMode,
 }: MicButtonProps) {
   const isRecording = phase === 'recording'
+  const isAuto = mode === 'auto'
+  const hints = PHASE_HINTS[mode] ?? PHASE_HINTS['push-to-talk']
 
   return (
     <div className="sticky bottom-0 z-20 flex flex-col items-center gap-2 pb-6 pt-3 bg-gradient-to-t from-background via-background to-transparent">
       <span className="text-xs text-muted-foreground">
-        {!connected
-          ? 'Connecting...'
-          : PHASE_HINTS[phase] ?? 'Tap or hold space'}
+        {!connected ? 'Connecting...' : hints[phase] ?? hints.idle}
       </span>
+      <div className="flex items-center gap-4">
+        <button
+          type="button"
+          onClick={isRecording ? onStop : onStart}
+          disabled={!connected || busy}
+          className={`relative inline-flex items-center justify-center w-16 h-16 rounded-full transition-all duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:opacity-40 disabled:cursor-not-allowed ${
+            isRecording
+              ? 'bg-red-500/20 border-2 border-red-500 text-red-400 hover:bg-red-500/30'
+              : isAuto && (phase === 'idle' || phase === 'done')
+                ? 'bg-green-500/10 border-2 border-green-500/40 text-green-400 hover:bg-green-500/20'
+                : busy
+                  ? 'bg-primary/5 border-2 border-primary/20 text-primary/50'
+                  : 'bg-primary/10 border-2 border-primary/40 text-primary hover:bg-primary/20 hover:border-primary/60 active:scale-95'
+          }`}
+        >
+          {isRecording && (
+            <span className="absolute inset-0 rounded-full animate-pulse-ring bg-red-500/20" />
+          )}
+          {isAuto && !isRecording && !busy && (
+            <span className="absolute inset-0 rounded-full animate-pulse bg-green-500/5" />
+          )}
+          {busy && !isAuto && (
+            <span className="absolute inset-0 rounded-full animate-pulse bg-primary/10" />
+          )}
+          {isRecording ? (
+            <StopIcon className="w-7 h-7 relative z-10" />
+          ) : (
+            <MicIcon className="w-7 h-7 relative z-10" />
+          )}
+        </button>
+      </div>
       <button
         type="button"
-        onClick={isRecording ? onStop : onStart}
-        disabled={!connected || busy}
-        className={`relative inline-flex items-center justify-center w-16 h-16 rounded-full transition-all duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:opacity-40 disabled:cursor-not-allowed ${
-          isRecording
-            ? 'bg-red-500/20 border-2 border-red-500 text-red-400 hover:bg-red-500/30'
-            : busy
-              ? 'bg-primary/5 border-2 border-primary/20 text-primary/50'
-              : 'bg-primary/10 border-2 border-primary/40 text-primary hover:bg-primary/20 hover:border-primary/60 active:scale-95'
-        }`}
+        onClick={onToggleMode}
+        className="text-xs text-muted-foreground/60 hover:text-muted-foreground transition-colors"
       >
-        {isRecording && (
-          <span className="absolute inset-0 rounded-full animate-pulse-ring bg-red-500/20" />
-        )}
-        {busy && (
-          <span className="absolute inset-0 rounded-full animate-pulse bg-primary/10" />
-        )}
-        {isRecording ? (
-          <StopIcon className="w-7 h-7 relative z-10" />
-        ) : (
-          <MicIcon className="w-7 h-7 relative z-10" />
-        )}
+        {isAuto ? 'Switch to tap-to-talk' : 'Switch to auto'}
       </button>
     </div>
   )

--- a/apps/web/app/hooks/use-audio-socket.ts
+++ b/apps/web/app/hooks/use-audio-socket.ts
@@ -407,5 +407,8 @@ export function useAudioSocket(wsUrl: string | null) {
     state.phase !== 'done' &&
     state.phase !== 'recording'
 
-  return { ...state, busy, startRecording, stopRecording, sendConversation }
+  // Expose the mic stream so VAD can attach to it
+  const micStream = streamRef.current
+
+  return { ...state, busy, startRecording, stopRecording, micStream }
 }

--- a/apps/web/app/hooks/use-vad.ts
+++ b/apps/web/app/hooks/use-vad.ts
@@ -1,0 +1,112 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+interface VADOptions {
+  /** RMS threshold below which audio is considered silence (0-1). Default: 0.01 */
+  silenceThreshold?: number
+  /** How long silence must persist before triggering speech end (ms). Default: 1500 */
+  silenceTimeout?: number
+  /** Minimum speech duration before silence detection kicks in (ms). Default: 500 */
+  minSpeechDuration?: number
+}
+
+interface VADState {
+  isSpeaking: boolean
+  silenceDuration: number
+}
+
+export function useVAD(
+  stream: MediaStream | null,
+  options: VADOptions = {},
+) {
+  const {
+    silenceThreshold = 0.01,
+    silenceTimeout = 1500,
+    minSpeechDuration = 500,
+  } = options
+
+  const analyserRef = useRef<AnalyserNode | null>(null)
+  const sourceRef = useRef<MediaStreamAudioSourceNode | null>(null)
+  const ctxRef = useRef<AudioContext | null>(null)
+  const rafRef = useRef<number>(0)
+  const speechStartRef = useRef<number>(0)
+  const lastSpeechRef = useRef<number>(0)
+
+  const [state, setState] = useState<VADState>({
+    isSpeaking: false,
+    silenceDuration: 0,
+  })
+
+  const onSpeechEndRef = useRef<(() => void) | null>(null)
+
+  const setOnSpeechEnd = useCallback((cb: (() => void) | null) => {
+    onSpeechEndRef.current = cb
+  }, [])
+
+  useEffect(() => {
+    if (!stream) {
+      setState({ isSpeaking: false, silenceDuration: 0 })
+      return
+    }
+
+    const ctx = new AudioContext()
+    ctxRef.current = ctx
+    const source = ctx.createMediaStreamSource(stream)
+    sourceRef.current = source
+    const analyser = ctx.createAnalyser()
+    analyser.fftSize = 512
+    analyser.smoothingTimeConstant = 0.3
+    source.connect(analyser)
+    analyserRef.current = analyser
+
+    const dataArray = new Float32Array(analyser.fftSize)
+    let speaking = false
+    let speechStart = 0
+    let lastSpeech = Date.now()
+
+    function tick() {
+      analyser.getFloatTimeDomainData(dataArray)
+
+      // Calculate RMS level
+      let sum = 0
+      for (let i = 0; i < dataArray.length; i++) {
+        sum += dataArray[i] * dataArray[i]
+      }
+      const rms = Math.sqrt(sum / dataArray.length)
+
+      const now = Date.now()
+
+      if (rms > silenceThreshold) {
+        if (!speaking) {
+          speaking = true
+          speechStart = now
+          speechStartRef.current = now
+        }
+        lastSpeech = now
+        lastSpeechRef.current = now
+        setState({ isSpeaking: true, silenceDuration: 0 })
+      } else if (speaking) {
+        const silence = now - lastSpeech
+        const speechDuration = now - speechStart
+        setState({ isSpeaking: true, silenceDuration: silence })
+
+        if (silence >= silenceTimeout && speechDuration >= minSpeechDuration) {
+          speaking = false
+          setState({ isSpeaking: false, silenceDuration: silence })
+          onSpeechEndRef.current?.()
+        }
+      }
+
+      rafRef.current = requestAnimationFrame(tick)
+    }
+
+    rafRef.current = requestAnimationFrame(tick)
+
+    return () => {
+      cancelAnimationFrame(rafRef.current)
+      source.disconnect()
+      ctx.close()
+    }
+  }, [stream, silenceThreshold, silenceTimeout, minSpeechDuration])
+
+  return { ...state, setOnSpeechEnd }
+}

--- a/apps/web/app/routes/home.tsx
+++ b/apps/web/app/routes/home.tsx
@@ -1,11 +1,15 @@
+import type { ConversationSummary } from '@voice-claude/contracts'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useOutletContext } from 'react-router'
 import { ChatMessage } from '../components/chat-message.js'
 import { ConnectionHeader } from '../components/connection-header.js'
+import { ConversationList } from '../components/conversation-list.js'
 import { MicButton } from '../components/mic-button.js'
 import { StatusIndicator } from '../components/status-indicator.js'
 import { useAudioSocket } from '../hooks/use-audio-socket.js'
 import { useSoundEffects } from '../hooks/use-sound-effects.js'
+import { useVAD } from '../hooks/use-vad.js'
+import { getClientTRPC } from '../trpc/client.js'
 
 interface RootContext {
   health: { status: string; timestamp: string } | null
@@ -40,18 +44,183 @@ export default function Home() {
     return `${protocol}//${window.location.hostname}:${wsConfig.port}${wsConfig.path}`
   }, [wsConfig])
 
+  const trpc = useMemo(() => {
+    if (typeof window === 'undefined' || !wsConfig) return null
+    return getClientTRPC(wsConfig.port)
+  }, [wsConfig])
+
   const audio = useAudioSocket(wsUrl)
   const { play } = useSoundEffects()
   const phaseRef = useRef(audio.phase)
   const spaceDownRef = useRef(false)
+
+  // Mode: push-to-talk (default) or auto (always-listening with VAD)
+  const [mode, setMode] = useState<'push-to-talk' | 'auto'>('push-to-talk')
+  const toggleMode = useCallback(() => {
+    setMode((m) => (m === 'push-to-talk' ? 'auto' : 'push-to-talk'))
+  }, [])
+
+  // VAD for auto mode
+  const vad = useVAD(mode === 'auto' ? audio.micStream : null, {
+    silenceThreshold: 0.01,
+    silenceTimeout: 1500,
+  })
+
+  // In auto mode, start recording when connected and idle
+  useEffect(() => {
+    if (
+      mode === 'auto' &&
+      audio.connected &&
+      (audio.phase === 'idle' || audio.phase === 'done') &&
+      !audio.busy
+    ) {
+      audio.startRecording()
+    }
+  }, [mode, audio.connected, audio.phase, audio.busy, audio.startRecording])
+
+  // In auto mode, stop recording when VAD detects silence after speech
+  useEffect(() => {
+    if (mode !== 'auto') return
+    vad.setOnSpeechEnd(() => {
+      if (audio.phase === 'recording') {
+        console.log('[auto] VAD detected speech end, sending...')
+        audio.stopRecording()
+      }
+    })
+    return () => vad.setOnSpeechEnd(null)
+  }, [mode, vad, audio])
   const scrollRef = useRef<HTMLDivElement>(null)
   const nextIdRef = useRef(1)
 
-  // Conversation history
+  // Conversation history (in-memory for current session)
   const [conversation, setConversation] = useState<ConversationEntry[]>([])
   const [pendingEntry, setPendingEntry] = useState<ConversationEntry | null>(
     null,
   )
+
+  // Conversation management
+  const [drawerOpen, setDrawerOpen] = useState(false)
+  const [conversations, setConversations] = useState<ConversationSummary[]>([])
+  const [activeConversationId, setActiveConversationId] = useState<
+    string | null
+  >(null)
+  const isFirstMessageRef = useRef(true)
+
+  // Fetch conversation list
+  const refreshConversations = useCallback(async () => {
+    if (!trpc) return
+    try {
+      const list = await trpc.conversations.list.query()
+      setConversations(list)
+    } catch (err) {
+      console.error('[home] failed to fetch conversations:', err)
+    }
+  }, [trpc])
+
+  // Fetch on mount
+  useEffect(() => {
+    refreshConversations()
+  }, [refreshConversations])
+
+  // Create a new conversation and tell the server about it
+  const createNewConversation = useCallback(async () => {
+    if (!trpc) return
+    try {
+      const conv = await trpc.conversations.create.mutate()
+      setActiveConversationId(conv.id)
+      isFirstMessageRef.current = true
+      setConversation([])
+      setPendingEntry(null)
+      nextIdRef.current = 1
+      audio.sendConversation(conv.id, true)
+      refreshConversations()
+      setDrawerOpen(false)
+    } catch (err) {
+      console.error('[home] failed to create conversation:', err)
+    }
+  }, [trpc, audio, refreshConversations])
+
+  // Select existing conversation and load its messages
+  const selectConversation = useCallback(
+    async (id: string) => {
+      if (!trpc) return
+      try {
+        const data = await trpc.conversations.get.query({ id })
+        if (!data) return
+        setActiveConversationId(id)
+        isFirstMessageRef.current = data.messages.length === 0
+
+        // Convert persisted messages to ConversationEntry pairs
+        const entries: ConversationEntry[] = []
+        let entryId = 1
+        const msgs = data.messages
+        for (let i = 0; i < msgs.length; i++) {
+          const msg = msgs[i]
+          if (!msg) continue
+          if (msg.role === 'user') {
+            const next = msgs[i + 1]
+            const entry: ConversationEntry = {
+              id: entryId++,
+              userText: msg.content,
+              userError: msg.error ?? null,
+            }
+            if (next?.role === 'assistant') {
+              entry.assistantText = next.content
+              entry.assistantError = next.error ?? null
+              entry.toolCalls = next.toolCalls
+              i++ // skip assistant message
+            }
+            entries.push(entry)
+          }
+        }
+        setConversation(entries)
+        setPendingEntry(null)
+        nextIdRef.current = entryId
+        audio.sendConversation(id, isFirstMessageRef.current)
+        setDrawerOpen(false)
+      } catch (err) {
+        console.error('[home] failed to load conversation:', err)
+      }
+    },
+    [trpc, audio],
+  )
+
+  // Delete conversation
+  const deleteConversation = useCallback(
+    async (id: string) => {
+      if (!trpc) return
+      try {
+        await trpc.conversations.delete.mutate({ id })
+        if (activeConversationId === id) {
+          setActiveConversationId(null)
+          setConversation([])
+          setPendingEntry(null)
+          nextIdRef.current = 1
+          audio.sendConversation(null, true)
+        }
+        refreshConversations()
+      } catch (err) {
+        console.error('[home] failed to delete conversation:', err)
+      }
+    },
+    [trpc, activeConversationId, audio, refreshConversations],
+  )
+
+  // Auto-create conversation on first recording if none active
+  const handleStartRecording = useCallback(async () => {
+    if (!activeConversationId && trpc) {
+      try {
+        const conv = await trpc.conversations.create.mutate()
+        setActiveConversationId(conv.id)
+        isFirstMessageRef.current = true
+        audio.sendConversation(conv.id, true)
+        refreshConversations()
+      } catch (err) {
+        console.error('[home] failed to auto-create conversation:', err)
+      }
+    }
+    audio.startRecording()
+  }, [activeConversationId, trpc, audio, refreshConversations])
 
   // When transcription arrives, start a new pending entry
   const prevTranscriptionRef = useRef<string | null>(null)
@@ -95,6 +264,9 @@ export default function Home() {
         }
         setConversation((prev) => [...prev, finalized])
         setPendingEntry(null)
+        isFirstMessageRef.current = false
+        // Refresh list to pick up auto-title and updated timestamps
+        refreshConversations()
       }
     }
     phaseRef.current = audio.phase
@@ -104,6 +276,7 @@ export default function Home() {
     audio.claudeError,
     audio.toolCalls,
     pendingEntry,
+    refreshConversations,
   ])
 
   // Auto-scroll to bottom
@@ -161,7 +334,7 @@ export default function Home() {
         audio.connected &&
         !audio.busy
       ) {
-        audio.startRecording()
+        handleStartRecording()
       }
     }
 
@@ -183,7 +356,7 @@ export default function Home() {
       window.removeEventListener('keydown', handleKeyDown)
       window.removeEventListener('keyup', handleKeyUp)
     }
-  }, [audio])
+  }, [audio, handleStartRecording])
 
   const showStatus =
     audio.phase === 'recording' ||
@@ -196,6 +369,17 @@ export default function Home() {
 
   return (
     <div className="flex flex-col h-dvh max-w-2xl mx-auto">
+      {/* Conversation drawer */}
+      <ConversationList
+        open={drawerOpen}
+        conversations={conversations}
+        activeId={activeConversationId}
+        onSelect={selectConversation}
+        onNew={createNewConversation}
+        onDelete={deleteConversation}
+        onClose={() => setDrawerOpen(false)}
+      />
+
       {/* Voice command toast */}
       {audio.commandNotice && (
         <div className="fixed top-16 left-1/2 -translate-x-1/2 z-50 animate-fade-in-up">
@@ -209,6 +393,7 @@ export default function Home() {
       <ConnectionHeader
         apiConnected={health?.status === 'ok'}
         wsConnected={audio.connected}
+        onMenuToggle={() => setDrawerOpen((o) => !o)}
       />
 
       {/* Scrollable chat area */}
@@ -283,8 +468,10 @@ export default function Home() {
         phase={audio.phase}
         connected={audio.connected}
         busy={audio.busy}
-        onStart={audio.startRecording}
+        mode={mode}
+        onStart={handleStartRecording}
         onStop={audio.stopRecording}
+        onToggleMode={toggleMode}
       />
     </div>
   )


### PR DESCRIPTION
## Summary
Phase 1 of always-listening: continuous mic with Voice Activity Detection that auto-sends when you stop speaking.

- **`use-vad.ts`** — VAD hook using AnalyserNode RMS level detection
- **Mode toggle** — push-to-talk (default) vs auto mode
- In auto mode: mic stays open, VAD detects speech end (1.5s silence), auto-sends
- **mic-button.tsx** — green listening indicator in auto mode, mode-aware hints
- Push-to-talk remains the default

## Test plan
- [ ] Push-to-talk mode works as before (default)
- [ ] Toggle to auto — mic opens, speak and pause — sends automatically
- [ ] Audio plays back, then mic reopens for next utterance

🤖 Generated with [Claude Code](https://claude.com/claude-code)