### PR TITLE
Add persistent conversation history with JSONL storage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ build/
 *.log
 .DS_Store
 .turbo
+data/

--- a/apps/server/src/storage/conversations.ts
+++ b/apps/server/src/storage/conversations.ts
@@ -1,0 +1,118 @@
+import { randomUUID } from 'node:crypto'
+import { appendFileSync, existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+import type { ConversationSummary, Message } from '@voice-claude/contracts'
+
+const DATA_DIR = join(process.cwd(), 'data', 'conversations')
+const INDEX_FILE = join(DATA_DIR, 'index.jsonl')
+
+function ensureDataDir() {
+  if (!existsSync(DATA_DIR)) {
+    mkdirSync(DATA_DIR, { recursive: true })
+  }
+  if (!existsSync(INDEX_FILE)) {
+    writeFileSync(INDEX_FILE, '')
+  }
+}
+
+function convFile(id: string): string {
+  return join(DATA_DIR, `conv_${id}.jsonl`)
+}
+
+function readJsonlLines<T>(filePath: string): T[] {
+  if (!existsSync(filePath)) return []
+  const content = readFileSync(filePath, 'utf-8').trim()
+  if (!content) return []
+  return content.split('\n').map((line) => JSON.parse(line) as T)
+}
+
+function appendJsonl(filePath: string, obj: unknown) {
+  appendFileSync(filePath, `${JSON.stringify(obj)}\n`)
+}
+
+function rewriteIndex(entries: ConversationSummary[]) {
+  writeFileSync(INDEX_FILE, entries.map((e) => JSON.stringify(e)).join('\n') + (entries.length ? '\n' : ''))
+}
+
+// ── Public API ──────────────────────────────────────────────────
+
+export function listConversations(): ConversationSummary[] {
+  ensureDataDir()
+  return readJsonlLines<ConversationSummary>(INDEX_FILE).sort(
+    (a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime(),
+  )
+}
+
+export function createConversation(title?: string): ConversationSummary {
+  ensureDataDir()
+  const now = new Date().toISOString()
+  const summary: ConversationSummary = {
+    id: randomUUID(),
+    title: title ?? 'New conversation',
+    createdAt: now,
+    updatedAt: now,
+    messageCount: 0,
+  }
+  appendJsonl(INDEX_FILE, summary)
+  writeFileSync(convFile(summary.id), '')
+  return summary
+}
+
+export function getConversation(id: string): { summary: ConversationSummary; messages: Message[] } | null {
+  ensureDataDir()
+  const entries = readJsonlLines<ConversationSummary>(INDEX_FILE)
+  const summary = entries.find((e) => e.id === id)
+  if (!summary) return null
+  const messages = readJsonlLines<Message>(convFile(id))
+  return { summary, messages }
+}
+
+export function appendMessage(conversationId: string, message: Omit<Message, 'id' | 'timestamp'>): Message {
+  ensureDataDir()
+  const full: Message = {
+    ...message,
+    id: randomUUID(),
+    timestamp: new Date().toISOString(),
+  }
+  appendJsonl(convFile(conversationId), full)
+
+  // Update index entry
+  const entries = readJsonlLines<ConversationSummary>(INDEX_FILE)
+  const idx = entries.findIndex((e) => e.id === conversationId)
+  const entry = entries[idx]
+  if (entry) {
+    entry.messageCount++
+    entry.updatedAt = full.timestamp
+    rewriteIndex(entries)
+  }
+
+  return full
+}
+
+export function deleteConversation(id: string): boolean {
+  ensureDataDir()
+  const entries = readJsonlLines<ConversationSummary>(INDEX_FILE)
+  const filtered = entries.filter((e) => e.id !== id)
+  if (filtered.length === entries.length) return false
+  rewriteIndex(filtered)
+  const file = convFile(id)
+  if (existsSync(file)) unlinkSync(file)
+  return true
+}
+
+export function updateConversationTitle(id: string, title: string): boolean {
+  ensureDataDir()
+  const entries = readJsonlLines<ConversationSummary>(INDEX_FILE)
+  const idx = entries.findIndex((e) => e.id === id)
+  const entry = entries[idx]
+  if (!entry) return false
+  entry.title = title
+  entry.updatedAt = new Date().toISOString()
+  rewriteIndex(entries)
+  return true
+}
+
+export function autoTitle(conversationId: string, firstUserMessage: string) {
+  const title = firstUserMessage.slice(0, 60) + (firstUserMessage.length > 60 ? '…' : '')
+  updateConversationTitle(conversationId, title)
+}

--- a/apps/server/src/trpc/router.ts
+++ b/apps/server/src/trpc/router.ts
@@ -1,3 +1,11 @@
+import { z } from 'zod/v4'
+import {
+  listConversations,
+  createConversation,
+  getConversation,
+  deleteConversation,
+  updateConversationTitle,
+} from '../storage/conversations.js'
 import { getStats } from '../voice/cost-tracker.js'
 import { createRouter, publicProcedure } from './init.js'
 
@@ -15,6 +23,31 @@ export const appRouter = createRouter({
   }),
   stats: publicProcedure.query(() => {
     return getStats()
+  }),
+  conversations: createRouter({
+    list: publicProcedure.query(() => {
+      return listConversations()
+    }),
+    get: publicProcedure
+      .input(z.object({ id: z.string() }))
+      .query(({ input }) => {
+        return getConversation(input.id)
+      }),
+    create: publicProcedure
+      .input(z.object({ title: z.string().optional() }).optional())
+      .mutation(({ input }) => {
+        return createConversation(input?.title)
+      }),
+    delete: publicProcedure
+      .input(z.object({ id: z.string() }))
+      .mutation(({ input }) => {
+        return deleteConversation(input.id)
+      }),
+    updateTitle: publicProcedure
+      .input(z.object({ id: z.string(), title: z.string() }))
+      .mutation(({ input }) => {
+        return updateConversationTitle(input.id, input.title)
+      }),
   }),
 })
 

--- a/apps/server/src/ws/audio.ts
+++ b/apps/server/src/ws/audio.ts
@@ -238,7 +238,6 @@ async function handleControl(
             role: 'assistant',
             content: response.text ?? '',
             toolCalls: response.toolCalls,
-            error: undefined,
           })
         }
 

--- a/apps/web/app/components/connection-header.tsx
+++ b/apps/web/app/components/connection-header.tsx
@@ -1,19 +1,34 @@
 interface ConnectionHeaderProps {
   apiConnected: boolean
   wsConnected: boolean
+  onMenuToggle?: () => void
 }
 
 export function ConnectionHeader({
   apiConnected,
   wsConnected,
+  onMenuToggle,
 }: ConnectionHeaderProps) {
   const allGood = apiConnected && wsConnected
 
   return (
     <header className="sticky top-0 z-20 flex items-center justify-between px-4 py-3 bg-background/80 backdrop-blur-md border-b border-border">
-      <h1 className="text-lg font-semibold tracking-tight text-foreground">
-        Voice Claude
-      </h1>
+      <div className="flex items-center gap-2">
+        {onMenuToggle && (
+          <button
+            type="button"
+            onClick={onMenuToggle}
+            className="text-muted-foreground hover:text-foreground p-1 -ml-1"
+          >
+            <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" d="M3.75 6.75h16.5M3.75 12h16.5m-16.5 5.25h16.5" />
+            </svg>
+          </button>
+        )}
+        <h1 className="text-lg font-semibold tracking-tight text-foreground">
+          Voice Claude
+        </h1>
+      </div>
       <div className="flex items-center gap-2">
         <div
           className={`w-2 h-2 rounded-full transition-colors ${

--- a/apps/web/app/components/conversation-list.tsx
+++ b/apps/web/app/components/conversation-list.tsx
@@ -1,0 +1,118 @@
+import type { ConversationSummary } from '@voice-claude/contracts'
+import { Button } from '@voice-claude/ui/components/Button'
+
+interface ConversationListProps {
+  open: boolean
+  conversations: ConversationSummary[]
+  activeId: string | null
+  onSelect: (id: string) => void
+  onNew: () => void
+  onDelete: (id: string) => void
+  onClose: () => void
+}
+
+function formatRelative(iso: string): string {
+  const diff = Date.now() - new Date(iso).getTime()
+  const mins = Math.floor(diff / 60_000)
+  if (mins < 1) return 'just now'
+  if (mins < 60) return `${mins}m ago`
+  const hours = Math.floor(mins / 60)
+  if (hours < 24) return `${hours}h ago`
+  const days = Math.floor(hours / 24)
+  if (days < 7) return `${days}d ago`
+  return new Date(iso).toLocaleDateString()
+}
+
+export function ConversationList({
+  open,
+  conversations,
+  activeId,
+  onSelect,
+  onNew,
+  onDelete,
+  onClose,
+}: ConversationListProps) {
+  return (
+    <>
+      {/* Backdrop */}
+      {open && (
+        <div
+          className="fixed inset-0 z-40 bg-black/50 backdrop-blur-sm"
+          onClick={onClose}
+          onKeyDown={(e) => e.key === 'Escape' && onClose()}
+        />
+      )}
+
+      {/* Drawer */}
+      <div
+        className={`fixed top-0 left-0 z-50 h-full w-72 bg-background border-r border-border transform transition-transform duration-200 ease-out ${
+          open ? 'translate-x-0' : '-translate-x-full'
+        }`}
+      >
+        <div className="flex flex-col h-full">
+          {/* Header */}
+          <div className="flex items-center justify-between px-4 py-3 border-b border-border">
+            <h2 className="text-sm font-semibold text-foreground">History</h2>
+            <button
+              type="button"
+              onClick={onClose}
+              className="text-muted-foreground hover:text-foreground p-1"
+            >
+              <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" d="M6 18 18 6M6 6l12 12" />
+              </svg>
+            </button>
+          </div>
+
+          {/* New conversation button */}
+          <div className="px-3 py-2">
+            <Button variant="outline" size="sm" className="w-full" onClick={onNew}>
+              <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" d="M12 4.5v15m7.5-7.5h-15" />
+              </svg>
+              New conversation
+            </Button>
+          </div>
+
+          {/* List */}
+          <div className="flex-1 overflow-y-auto px-2 py-1">
+            {conversations.length === 0 && (
+              <p className="text-xs text-muted-foreground text-center py-6">No conversations yet</p>
+            )}
+            {conversations.map((conv) => (
+              <button
+                key={conv.id}
+                type="button"
+                onClick={() => onSelect(conv.id)}
+                className={`w-full text-left rounded-lg px-3 py-2.5 mb-0.5 group transition-colors ${
+                  conv.id === activeId
+                    ? 'bg-primary/10 text-foreground'
+                    : 'text-muted-foreground hover:bg-secondary/50 hover:text-foreground'
+                }`}
+              >
+                <div className="flex items-start justify-between gap-2">
+                  <p className="text-sm truncate flex-1">{conv.title}</p>
+                  <button
+                    type="button"
+                    onClick={(e) => {
+                      e.stopPropagation()
+                      onDelete(conv.id)
+                    }}
+                    className="opacity-0 group-hover:opacity-100 text-muted-foreground hover:text-destructive p-0.5 -mr-1 shrink-0"
+                  >
+                    <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor">
+                      <path strokeLinecap="round" strokeLinejoin="round" d="m14.74 9-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 0 1-2.244 2.077H8.084a2.25 2.25 0 0 1-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 0 0-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 0 1 3.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 0 0-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 0 0-7.5 0" />
+                    </svg>
+                  </button>
+                </div>
+                <p className="text-xs text-muted-foreground mt-0.5">
+                  {formatRelative(conv.updatedAt)} · {conv.messageCount} msg{conv.messageCount !== 1 ? 's' : ''}
+                </p>
+              </button>
+            ))}
+          </div>
+        </div>
+      </div>
+    </>
+  )
+}

--- a/apps/web/app/hooks/use-audio-socket.ts
+++ b/apps/web/app/hooks/use-audio-socket.ts
@@ -410,5 +410,5 @@ export function useAudioSocket(wsUrl: string | null) {
   // Expose the mic stream so VAD can attach to it
   const micStream = streamRef.current
 
-  return { ...state, busy, startRecording, stopRecording, micStream }
+  return { ...state, busy, startRecording, stopRecording, micStream, sendConversation }
 }

--- a/apps/web/app/trpc/client.ts
+++ b/apps/web/app/trpc/client.ts
@@ -1,0 +1,18 @@
+import type { AppRouter } from '@voice-claude/server/trpc/router'
+import { createTRPCClient, httpBatchLink } from '@trpc/client'
+
+let _client: ReturnType<typeof createTRPCClient<AppRouter>> | null = null
+let _currentPort: number | null = null
+
+export function getClientTRPC(serverPort: number) {
+  if (_client && _currentPort === serverPort) return _client
+
+  const url = `${window.location.protocol}//${window.location.hostname}:${serverPort}/trpc`
+
+  _client = createTRPCClient<AppRouter>({
+    links: [httpBatchLink({ url })],
+  })
+  _currentPort = serverPort
+
+  return _client
+}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -13,6 +13,7 @@
     "typecheck": "react-router typegen && tsc --noEmit"
   },
   "dependencies": {
+    "@voice-claude/contracts": "workspace:*",
     "@voice-claude/server": "workspace:*",
     "@voice-claude/ui": "workspace:*",
     "@hono/node-server": "^1.18.1",

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -6,3 +6,35 @@ export const heartbeatResponseSchema = z.object({
 })
 
 export type HeartbeatResponse = z.infer<typeof heartbeatResponseSchema>
+
+// ── Chat History ────────────────────────────────────────────────
+
+export const toolCallSchema = z.object({
+  name: z.string(),
+  input: z.string(),
+  result: z.string(),
+})
+
+export type ToolCall = z.infer<typeof toolCallSchema>
+
+export const messageSchema = z.object({
+  id: z.string(),
+  role: z.enum(['user', 'assistant']),
+  content: z.string(),
+  timestamp: z.iso.datetime(),
+  error: z.string().optional(),
+  toolCalls: z.array(toolCallSchema).optional(),
+  model: z.string().optional(),
+})
+
+export type Message = z.infer<typeof messageSchema>
+
+export const conversationSummarySchema = z.object({
+  id: z.string(),
+  title: z.string(),
+  createdAt: z.iso.datetime(),
+  updatedAt: z.iso.datetime(),
+  messageCount: z.number(),
+})
+
+export type ConversationSummary = z.infer<typeof conversationSummarySchema>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -72,6 +72,9 @@ importers:
       '@trpc/client':
         specifier: ^11.0.0
         version: 11.16.0(@trpc/server@11.16.0(typescript@5.9.3))(typescript@5.9.3)
+      '@voice-claude/contracts':
+        specifier: workspace:*
+        version: link:../../packages/contracts
       '@voice-claude/server':
         specifier: workspace:*
         version: link:../server


### PR DESCRIPTION
## Summary
- **JSONL file storage** for conversations (`data/conversations/`) — append-only writes, no database needed
- **Contract schemas** (`Message`, `ToolCall`, `ConversationSummary`) in `@voice-claude/contracts`
- **tRPC CRUD routes** for `conversations.{list, get, create, delete, updateTitle}`
- **WebSocket persistence** — user and assistant messages saved after each interaction, auto-title from first user message
- **Conversation drawer UI** — slide-out panel with history list, new/select/delete actions
- **Client-side tRPC** setup for browser-side API calls
- Auto-creates a conversation on first recording if none is active

## Test plan
- [ ] Start the app and verify the hamburger menu appears in the header
- [ ] Tap mic, send a message, and confirm it persists (check `data/conversations/`)
- [ ] Open drawer, verify the conversation appears with auto-generated title
- [ ] Create a new conversation from the drawer
- [ ] Select an old conversation and verify history loads
- [ ] Delete a conversation and verify it's removed from drawer and disk
- [ ] Refresh the page and confirm conversations persist across sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)