### PR TITLE
Fix auto-mode toggle sending audio when switching to tap-to-talk

### DIFF
--- a/apps/web/app/hooks/use-audio-socket.ts
+++ b/apps/web/app/hooks/use-audio-socket.ts
@@ -391,6 +391,30 @@ export function useAudioSocket(wsUrl: string | null) {
     console.log('[audio] recording stopped, requesting transcription')
   }, [])
 
+  const cancelRecording = useCallback(() => {
+    const mediaRecorder = mediaRecorderRef.current
+    if (mediaRecorder && mediaRecorder.state !== 'inactive') {
+      mediaRecorder.stop()
+    }
+    mediaRecorderRef.current = null
+
+    const stream = streamRef.current
+    if (stream) {
+      for (const track of stream.getTracks()) {
+        track.stop()
+      }
+    }
+    streamRef.current = null
+    chunksRef.current = []
+
+    setState((s) => ({
+      ...s,
+      phase: 'idle',
+    }))
+
+    console.log('[audio] recording cancelled, no audio sent')
+  }, [])
+
   const sendConversation = useCallback(
     (conversationId: string | null, isFirstMessage: boolean) => {
       const ws = wsRef.current
@@ -415,5 +439,5 @@ export function useAudioSocket(wsUrl: string | null) {
   // Expose the mic stream so VAD can attach to it
   const micStream = streamRef.current
 
-  return { ...state, busy, startRecording, stopRecording, micStream, sendConversation }
+  return { ...state, busy, startRecording, stopRecording, cancelRecording, micStream, sendConversation }
 }

--- a/apps/web/app/routes/home.tsx
+++ b/apps/web/app/routes/home.tsx
@@ -57,8 +57,17 @@ export default function Home() {
   // Mode: push-to-talk (default) or auto (always-listening with VAD)
   const [mode, setMode] = useState<'push-to-talk' | 'auto'>('push-to-talk')
   const toggleMode = useCallback(() => {
-    setMode((m) => (m === 'push-to-talk' ? 'auto' : 'push-to-talk'))
-  }, [])
+    setMode((m) => {
+      if (m === 'auto') {
+        // Switching to push-to-talk: cancel any in-progress recording without sending
+        if (audio.phase === 'recording') {
+          audio.cancelRecording()
+        }
+        return 'push-to-talk'
+      }
+      return 'auto'
+    })
+  }, [audio])
 
   // VAD for auto mode
   const vad = useVAD(mode === 'auto' ? audio.micStream : null, {


### PR DESCRIPTION
## Summary
- Add `cancelRecording()` method to `useAudioSocket` that stops the mic and discards buffered audio without sending
- Toggle from auto to push-to-talk now calls `cancelRecording()` instead of letting `stopRecording()` fire, preventing accidental sends

## Test plan
- [ ] In auto mode, click "Switch to tap-to-talk" — mic stops, no audio sent, no transcription triggered
- [ ] Push-to-talk still works normally after switching back
- [ ] Auto mode still auto-sends on speech end as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)