### PR TITLE
Restore Claude session context when switching conversations

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -43,3 +43,6 @@ OPENAI_API_KEY=sk-...
 
 # Working directory for Claude tool execution (defaults to cwd)
 # WORK_DIR=/path/to/your/projects
+
+# Conversation history storage (production Docker only, defaults to ./data/conversations)
+# CONVERSATIONS_DIR=./data/conversations

--- a/apps/server/src/voice/claude.ts
+++ b/apps/server/src/voice/claude.ts
@@ -363,3 +363,20 @@ export function clearSession(sessionId: string) {
   sessions.delete(sessionId)
   toolSessions.delete(sessionId)
 }
+
+export function restoreSession(
+  sessionId: string,
+  history: Array<{ role: 'user' | 'assistant'; content: string }>,
+) {
+  const messages: Anthropic.MessageParam[] = []
+  for (const msg of history) {
+    if (msg.content) {
+      messages.push({ role: msg.role, content: msg.content })
+    }
+  }
+  sessions.set(sessionId, messages)
+  if (history.some((m) => m.role === 'assistant')) {
+    toolSessions.add(sessionId)
+  }
+  console.log(`[claude] restored session ${sessionId.slice(0, 8)} with ${messages.length} messages`)
+}

--- a/apps/server/src/ws/audio.ts
+++ b/apps/server/src/ws/audio.ts
@@ -4,8 +4,9 @@ import { WebSocketServer, type WebSocket } from 'ws'
 import {
   appendMessage,
   autoTitle,
+  getConversation,
 } from '../storage/conversations.js'
-import { chat, clearSession } from '../voice/claude.js'
+import { chat, clearSession, restoreSession } from '../voice/claude.js'
 import { parseCommand } from '../voice/commands.js'
 import {
   recordSTT,
@@ -61,6 +62,19 @@ export function attachWebSocket(httpServer: Server) {
             conversationId = msg.conversationId ?? null
             isFirstMessage = msg.isFirstMessage ?? true
             console.log(`[ws] conversation set to ${conversationId?.slice(0, 8) ?? 'none'}`)
+
+            // Restore Claude session from persisted messages
+            clearSession(sessionId)
+            if (conversationId) {
+              const conv = getConversation(conversationId)
+              if (conv && conv.messages.length > 0) {
+                restoreSession(sessionId, conv.messages.map((m) => ({
+                  role: m.role,
+                  content: m.content,
+                })))
+              }
+            }
+
             send(ws, { type: 'conversation_set', conversationId })
             return
           }

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -14,6 +14,7 @@ services:
       PIPER_URL: http://piper:5000
     volumes:
       - ${WORK_DIR:-./workspace}:/workspace
+      - ${CONVERSATIONS_DIR:-./data/conversations}:/app/data/conversations
     depends_on:
       piper:
         condition: service_healthy


### PR DESCRIPTION
## Summary
- Add `restoreSession()` to replay persisted messages into Claude's session when selecting a conversation
- Claude now remembers prior turns when switching back to an old conversation
- Add production Docker volume mount for conversation data persistence (`CONVERSATIONS_DIR`)
- Document `CONVERSATIONS_DIR` in `.env.example`

## Test plan
- [ ] Select an old conversation from the drawer — ask Claude about something discussed previously, it should remember
- [ ] Create a new conversation — Claude starts fresh with no prior context
- [ ] Restart the server — conversations persist and restore correctly
- [ ] Production docker-compose mounts `data/conversations/` as a volume

🤖 Generated with [Claude Code](https://claude.com/claude-code)