### PR TITLE
Fix TypeScript strict-mode errors and import casing

### DIFF
--- a/apps/web/app/components/conversation-list.tsx
+++ b/apps/web/app/components/conversation-list.tsx
@@ -1,5 +1,5 @@
 import type { ConversationSummary } from '@voice-claude/contracts'
-import { Button } from '@voice-claude/ui/components/Button'
+import { Button } from '@voice-claude/ui/components/button'
 
 interface ConversationListProps {
   open: boolean

--- a/apps/web/app/components/mic-button.tsx
+++ b/apps/web/app/components/mic-button.tsx
@@ -76,12 +76,12 @@ export function MicButton({
 }: MicButtonProps) {
   const isRecording = phase === 'recording'
   const isAuto = mode === 'auto'
-  const hints = PHASE_HINTS[mode] ?? PHASE_HINTS['push-to-talk']
+  const hints = PHASE_HINTS[mode] ?? PHASE_HINTS['push-to-talk'] ?? {}
 
   return (
     <div className="sticky bottom-0 z-20 flex flex-col items-center gap-2 pb-6 pt-3 bg-gradient-to-t from-background via-background to-transparent">
       <span className="text-xs text-muted-foreground">
-        {!connected ? 'Connecting...' : hints[phase] ?? hints.idle}
+        {!connected ? 'Connecting...' : (hints[phase] ?? hints.idle ?? 'Tap or hold space')}
       </span>
       <div className="flex items-center gap-4">
         <button

--- a/apps/web/app/hooks/use-sound-effects.ts
+++ b/apps/web/app/hooks/use-sound-effects.ts
@@ -150,7 +150,7 @@ function playCommandAcknowledged(ctx: AudioContext) {
     const gain = ctx.createGain()
     const start = now + i * 0.09
     osc.type = 'sine'
-    osc.frequency.value = notes[i]
+    osc.frequency.value = notes[i] ?? 0
     gain.gain.setValueAtTime(0, start)
     gain.gain.linearRampToValueAtTime(0.12, start + 0.02)
     gain.gain.linearRampToValueAtTime(0, start + 0.08)

--- a/apps/web/app/hooks/use-vad.ts
+++ b/apps/web/app/hooks/use-vad.ts
@@ -69,7 +69,8 @@ export function useVAD(
       // Calculate RMS level
       let sum = 0
       for (let i = 0; i < dataArray.length; i++) {
-        sum += dataArray[i] * dataArray[i]
+        const sample = dataArray[i] ?? 0
+        sum += sample * sample
       }
       const rms = Math.sqrt(sum / dataArray.length)
 


### PR DESCRIPTION
## Summary
- Fix 3 TypeScript strict-mode errors in the web app (`mic-button.tsx`, `use-sound-effects.ts`, `use-vad.ts`) by adding nullish coalescing fallbacks
- Fix case-sensitivity import bug in `conversation-list.tsx` (`Button` → `button`) that would break on Linux/CI

## Test plan
- [x] `pnpm typecheck` passes cleanly (6/6 tasks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)