### PR TITLE
Add workspace volume mount to dev docker-compose

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -41,8 +41,10 @@ OPENAI_API_KEY=sk-...
 # PIPER_MODELS_DIR=./models/piper             # host path to directory containing .onnx model files
 # PIPER_VOICE=                                # speaker name for multi-speaker models
 
-# Working directory for Claude tool execution (defaults to cwd)
-# WORK_DIR=/path/to/your/projects
+# Working directory for Claude tool execution
+# This is the host directory that gets mounted into the container at /workspace.
+# Claude's tools (shell, file read) operate inside this directory.
+# WORK_DIR=~/projects
 
 # Conversation history storage (production Docker only, defaults to ./data/conversations)
 # CONVERSATIONS_DIR=./data/conversations

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,9 +9,11 @@ services:
       - .env
     environment:
       PORT: "4000"
+      WORK_DIR: /workspace
       PIPER_URL: http://piper:5000
     volumes:
       - .:/app
+      - ${WORK_DIR:-./workspace}:/workspace
       - /app/node_modules
       - /app/apps/server/node_modules
       - /app/apps/web/node_modules


### PR DESCRIPTION
## Summary
- Mount `WORK_DIR` (or `./workspace` default) to `/workspace` in the dev server container
- Set `WORK_DIR=/workspace` env var so Claude tools operate on the mounted directory, not the app's cwd
- Updated `.env.example` to clarify `WORK_DIR` usage

## Test plan
- [x] `pnpm lint` passes
- [x] `pnpm typecheck` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)