### PR TITLE
Add graceful shutdown handlers for SIGTERM and SIGINT

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -13,4 +13,25 @@ const server = serve({ fetch: app.fetch, port }, () => {
   console.log(`WebSocket available at ws://localhost:${port}/ws/audio`)
 })
 
-attachWebSocket(server as unknown as Server)
+const wss = attachWebSocket(server as unknown as Server)
+
+function gracefulShutdown(signal: string) {
+  console.log(`[server] received ${signal}, shutting down gracefully...`)
+
+  for (const client of wss.clients) {
+    client.close(1001, 'Server shutting down')
+  }
+
+  server.close(() => {
+    console.log('[server] HTTP server closed')
+    process.exit(0)
+  })
+
+  setTimeout(() => {
+    console.log('[server] forced shutdown after timeout')
+    process.exit(1)
+  }, 5000).unref()
+}
+
+process.on('SIGTERM', () => gracefulShutdown('SIGTERM'))
+process.on('SIGINT', () => gracefulShutdown('SIGINT'))


### PR DESCRIPTION
- Close all WebSocket connections with code 1001 on shutdown
- Stop HTTP server from accepting new connections
- 5-second forced exit timeout as safety net