### PR TITLE
Add URL-based conversation routing

### DIFF
--- a/apps/web/app/components/conversation-list.tsx
+++ b/apps/web/app/components/conversation-list.tsx
@@ -1,11 +1,11 @@
 import type { ConversationSummary } from '@voice-claude/contracts'
 import { Button } from '@voice-claude/ui/components/button'
+import { Link } from 'react-router'
 
 interface ConversationListProps {
   open: boolean
   conversations: ConversationSummary[]
   activeId: string | null
-  onSelect: (id: string) => void
   onNew: () => void
   onDelete: (id: string) => void
   onClose: () => void
@@ -27,7 +27,6 @@ export function ConversationList({
   open,
   conversations,
   activeId,
-  onSelect,
   onNew,
   onDelete,
   onClose,
@@ -81,7 +80,10 @@ export function ConversationList({
               variant="outline"
               size="sm"
               className="w-full"
-              onClick={onNew}
+              onClick={() => {
+                onNew()
+                onClose()
+              }}
             >
               <svg
                 className="w-3.5 h-3.5"
@@ -109,11 +111,11 @@ export function ConversationList({
               </p>
             )}
             {conversations.map((conv) => (
-              <button
+              <Link
                 key={conv.id}
-                type="button"
-                onClick={() => onSelect(conv.id)}
-                className={`w-full text-left rounded-lg px-3 py-2.5 mb-0.5 group transition-colors ${
+                to={`/c/${conv.id}`}
+                onClick={onClose}
+                className={`block w-full text-left rounded-lg px-3 py-2.5 mb-0.5 group transition-colors ${
                   conv.id === activeId
                     ? 'bg-primary/10 text-foreground'
                     : 'text-muted-foreground hover:bg-secondary/50 hover:text-foreground'
@@ -124,6 +126,7 @@ export function ConversationList({
                   <button
                     type="button"
                     onClick={(e) => {
+                      e.preventDefault()
                       e.stopPropagation()
                       onDelete(conv.id)
                     }}
@@ -149,7 +152,7 @@ export function ConversationList({
                   {formatRelative(conv.updatedAt)} · {conv.messageCount} msg
                   {conv.messageCount !== 1 ? 's' : ''}
                 </p>
-              </button>
+              </Link>
             ))}
           </div>
         </div>

--- a/apps/web/app/routes.ts
+++ b/apps/web/app/routes.ts
@@ -2,5 +2,6 @@ import { type RouteConfig, index, route } from '@react-router/dev/routes'
 
 export default [
   index('routes/home.tsx'),
+  route('c/:conversationId', 'routes/home.tsx', { id: 'conversation' }),
   route('costs', 'routes/costs.tsx'),
 ] satisfies RouteConfig

--- a/apps/web/app/routes/home.tsx
+++ b/apps/web/app/routes/home.tsx
@@ -1,6 +1,6 @@
 import type { ConversationSummary } from '@voice-claude/contracts'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { useOutletContext } from 'react-router'
+import { useNavigate, useOutletContext, useParams } from 'react-router'
 import { ChatMessage } from '../components/chat-message.js'
 import { ConnectionHeader } from '../components/connection-header.js'
 import { ConversationList } from '../components/conversation-list.js'
@@ -110,9 +110,9 @@ export default function Home() {
   // Conversation management
   const [drawerOpen, setDrawerOpen] = useState(false)
   const [conversations, setConversations] = useState<ConversationSummary[]>([])
-  const [activeConversationId, setActiveConversationId] = useState<
-    string | null
-  >(null)
+  const params = useParams<{ conversationId?: string }>()
+  const activeConversationId = params.conversationId ?? null
+  const navigate = useNavigate()
   const isFirstMessageRef = useRef(true)
 
   // Fetch conversation list
@@ -131,68 +131,89 @@ export default function Home() {
     refreshConversations()
   }, [refreshConversations])
 
-  // Create a new conversation and tell the server about it
+  // Create a new conversation and navigate to it
   const createNewConversation = useCallback(async () => {
     if (!trpc) return
     try {
       const conv = await trpc.conversations.create.mutate()
-      setActiveConversationId(conv.id)
-      isFirstMessageRef.current = true
-      setConversation([])
-      setPendingEntry(null)
-      nextIdRef.current = 1
-      audio.sendConversation(conv.id, true)
       refreshConversations()
-      setDrawerOpen(false)
+      navigate(`/c/${conv.id}`)
     } catch (err) {
       console.error('[home] failed to create conversation:', err)
     }
-  }, [trpc, audio, refreshConversations])
+  }, [trpc, refreshConversations, navigate])
 
-  // Select existing conversation and load its messages
-  const selectConversation = useCallback(
-    async (id: string) => {
-      if (!trpc) return
-      try {
-        const data = await trpc.conversations.get.query({ id })
-        if (!data) return
-        setActiveConversationId(id)
-        isFirstMessageRef.current = data.messages.length === 0
+  // Load conversation data when activeConversationId changes (URL-driven)
+  useEffect(() => {
+    let cancelled = false
 
-        // Convert persisted messages to ConversationEntry pairs
-        const entries: ConversationEntry[] = []
-        let entryId = 1
-        const msgs = data.messages
-        for (let i = 0; i < msgs.length; i++) {
-          const msg = msgs[i]
-          if (!msg) continue
-          if (msg.role === 'user') {
-            const next = msgs[i + 1]
-            const entry: ConversationEntry = {
-              id: entryId++,
-              userText: msg.content,
-              userError: msg.error ?? null,
+    if (activeConversationId && trpc) {
+      const loadConversation = async () => {
+        try {
+          const data = await trpc.conversations.get.query({
+            id: activeConversationId,
+          })
+          if (cancelled) return
+          if (!data) {
+            navigate('/', { replace: true })
+            return
+          }
+          isFirstMessageRef.current = data.messages.length === 0
+
+          // Convert persisted messages to ConversationEntry pairs
+          const entries: ConversationEntry[] = []
+          let entryId = 1
+          const msgs = data.messages
+          for (let i = 0; i < msgs.length; i++) {
+            const msg = msgs[i]
+            if (!msg) continue
+            if (msg.role === 'user') {
+              const next = msgs[i + 1]
+              const entry: ConversationEntry = {
+                id: entryId++,
+                userText: msg.content,
+                userError: msg.error ?? null,
+              }
+              if (next?.role === 'assistant') {
+                entry.assistantText = next.content
+                entry.assistantError = next.error ?? null
+                entry.toolCalls = next.toolCalls
+                i++ // skip assistant message
+              }
+              entries.push(entry)
             }
-            if (next?.role === 'assistant') {
-              entry.assistantText = next.content
-              entry.assistantError = next.error ?? null
-              entry.toolCalls = next.toolCalls
-              i++ // skip assistant message
-            }
-            entries.push(entry)
+          }
+          setConversation(entries)
+          setPendingEntry(null)
+          nextIdRef.current = entryId
+          audio.sendConversation(
+            activeConversationId,
+            isFirstMessageRef.current,
+          )
+        } catch (err) {
+          console.error('[home] failed to load conversation:', err)
+          if (!cancelled) {
+            navigate('/', { replace: true })
           }
         }
-        setConversation(entries)
-        setPendingEntry(null)
-        nextIdRef.current = entryId
-        audio.sendConversation(id, isFirstMessageRef.current)
-        setDrawerOpen(false)
-      } catch (err) {
-        console.error('[home] failed to load conversation:', err)
       }
-    },
-    [trpc, audio],
-  )
+      loadConversation()
+    } else {
+      // No active conversation — clear state
+      setConversation([])
+      setPendingEntry(null)
+      nextIdRef.current = 1
+      isFirstMessageRef.current = true
+      audio.sendConversation(null, true)
+    }
+
+    // Close drawer when navigating
+    setDrawerOpen(false)
+
+    return () => {
+      cancelled = true
+    }
+  }, [activeConversationId, trpc, audio, navigate])
 
   // Delete conversation
   const deleteConversation = useCallback(
@@ -201,18 +222,14 @@ export default function Home() {
       try {
         await trpc.conversations.delete.mutate({ id })
         if (activeConversationId === id) {
-          setActiveConversationId(null)
-          setConversation([])
-          setPendingEntry(null)
-          nextIdRef.current = 1
-          audio.sendConversation(null, true)
+          navigate('/')
         }
         refreshConversations()
       } catch (err) {
         console.error('[home] failed to delete conversation:', err)
       }
     },
-    [trpc, activeConversationId, audio, refreshConversations],
+    [trpc, activeConversationId, navigate, refreshConversations],
   )
 
   // Auto-create conversation on first recording if none active
@@ -220,16 +237,16 @@ export default function Home() {
     if (!activeConversationId && trpc) {
       try {
         const conv = await trpc.conversations.create.mutate()
-        setActiveConversationId(conv.id)
         isFirstMessageRef.current = true
         audio.sendConversation(conv.id, true)
         refreshConversations()
+        navigate(`/c/${conv.id}`, { replace: true })
       } catch (err) {
         console.error('[home] failed to auto-create conversation:', err)
       }
     }
     audio.startRecording()
-  }, [activeConversationId, trpc, audio, refreshConversations])
+  }, [activeConversationId, trpc, audio, refreshConversations, navigate])
 
   // When transcription arrives, start a new pending entry
   const prevTranscriptionRef = useRef<string | null>(null)
@@ -397,7 +414,6 @@ export default function Home() {
         open={drawerOpen}
         conversations={conversations}
         activeId={activeConversationId}
-        onSelect={selectConversation}
         onNew={createNewConversation}
         onDelete={deleteConversation}
         onClose={() => setDrawerOpen(false)}


### PR DESCRIPTION
## Summary
- Conversation selection is now URL-driven (`/c/:conversationId`) instead of local React state
- `/` represents a new conversation, `/c/:id` loads an existing one
- Sidebar conversation items are now `<Link>` elements with proper navigation
- Browser back/forward and page refresh preserve conversation context

## Changes
- **`routes.ts`** — Added `/c/:conversationId` route (same component as index)
- **`home.tsx`** — Replaced `useState` with `useParams`/`useNavigate`; conversation loading moved to a `useEffect` watching the URL param
- **`conversation-list.tsx`** — Replaced `onSelect` callback buttons with `<Link to={/c/${id}}>` navigation

## Test plan
- [ ] Navigate to `/` — should show empty new conversation state
- [ ] Click a conversation in the sidebar — URL changes to `/c/:id`, messages load
- [ ] Press browser back — returns to previous conversation or `/`
- [ ] Refresh on `/c/:id` — conversation reloads correctly
- [ ] Start recording with no active conversation — auto-creates and navigates with `replace`
- [ ] Delete active conversation — navigates back to `/`
- [ ] Invalid `/c/nonexistent` — redirects to `/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)