### PR TITLE
Fix set_conversation WebSocket spam loop

### DIFF
--- a/apps/web/app/routes/home.tsx
+++ b/apps/web/app/routes/home.tsx
@@ -213,7 +213,8 @@ export default function Home() {
     return () => {
       cancelled = true
     }
-  }, [activeConversationId, trpc, audio, navigate])
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- audio.sendConversation is a stable useCallback
+  }, [activeConversationId, trpc, navigate])
 
   // Delete conversation
   const deleteConversation = useCallback(


### PR DESCRIPTION
## Summary
- Fixes rapid-fire `[ws] conversation set to none` log spam on the server
- Root cause: `audio` object in `useEffect` dep array is unstable (new object every render from `useAudioSocket`), causing the effect to re-fire on every state change
- Fix: remove `audio` from the dep array — `audio.sendConversation` is a stable `useCallback([])` that won't go stale

## Test plan
- [ ] Start the app and verify no `[ws] conversation set to none` spam in server logs
- [ ] Navigate between conversations — verify conversation state syncs correctly
- [ ] Navigate to home (no conversation) — verify a single `conversation set to none` log

🤖 Generated with [Claude Code](https://claude.com/claude-code)