### PR TITLE
Add expandable tool call results with syntax highlighting

### DIFF
--- a/apps/web/app/components/chat-message.tsx
+++ b/apps/web/app/components/chat-message.tsx
@@ -1,3 +1,6 @@
+import { useState } from 'react'
+import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter'
+import { oneDark } from 'react-syntax-highlighter/dist/esm/styles/prism'
 import { MarkdownContent } from './markdown-content'
 
 interface ToolCall {
@@ -14,7 +17,51 @@ interface ChatMessageProps {
   timestamp?: number
 }
 
-function ToolCallBadge({ toolCall }: { toolCall: ToolCall }) {
+const extToLang: Record<string, string> = {
+  ts: 'typescript',
+  tsx: 'tsx',
+  js: 'javascript',
+  jsx: 'jsx',
+  json: 'json',
+  py: 'python',
+  rs: 'rust',
+  go: 'go',
+  css: 'css',
+  html: 'html',
+  md: 'markdown',
+  yml: 'yaml',
+  yaml: 'yaml',
+  sh: 'bash',
+  bash: 'bash',
+  sql: 'sql',
+  toml: 'toml',
+  xml: 'xml',
+  rb: 'ruby',
+  java: 'java',
+  c: 'c',
+  cpp: 'cpp',
+  h: 'c',
+  hpp: 'cpp',
+}
+
+function inferLanguage(toolCall: ToolCall): string {
+  if (toolCall.name === 'run_shell') return 'bash'
+  try {
+    const parsed = JSON.parse(toolCall.input)
+    const path = parsed.path as string | undefined
+    if (path) {
+      const ext = path.split('.').pop()?.toLowerCase() ?? ''
+      return extToLang[ext] ?? 'text'
+    }
+  } catch {
+    // ignore
+  }
+  return 'text'
+}
+
+function ToolCallItem({ toolCall }: { toolCall: ToolCall }) {
+  const [expanded, setExpanded] = useState(false)
+
   let detail = '...'
   try {
     const parsed = JSON.parse(toolCall.input)
@@ -23,12 +70,53 @@ function ToolCallBadge({ toolCall }: { toolCall: ToolCall }) {
     // ignore
   }
 
+  const language = inferLanguage(toolCall)
+  const hasResult = toolCall.result && toolCall.result.length > 0
+
   return (
-    <div className="inline-flex items-center gap-1.5 text-xs font-mono bg-secondary/60 rounded-md px-2 py-1">
-      <span className="text-primary">{toolCall.name}</span>
-      <span className="text-muted-foreground truncate max-w-[180px]">
-        {detail}
-      </span>
+    <div className="w-full">
+      <button
+        type="button"
+        onClick={() => hasResult && setExpanded(!expanded)}
+        className={`inline-flex items-center gap-1.5 text-xs font-mono bg-secondary/60 rounded-md px-2 py-1 ${hasResult ? 'cursor-pointer hover:bg-secondary/80 transition-colors' : 'cursor-default'}`}
+      >
+        <span className="text-primary">{toolCall.name}</span>
+        <span className="text-muted-foreground truncate max-w-[180px]">
+          {detail}
+        </span>
+        {hasResult && (
+          <svg
+            className={`w-3 h-3 text-muted-foreground transition-transform ${expanded ? 'rotate-180' : ''}`}
+            viewBox="0 0 20 20"
+            fill="currentColor"
+            aria-hidden="true"
+          >
+            <path
+              fillRule="evenodd"
+              d="M5.23 7.21a.75.75 0 011.06.02L10 11.168l3.71-3.938a.75.75 0 111.08 1.04l-4.25 4.5a.75.75 0 01-1.08 0l-4.25-4.5a.75.75 0 01.02-1.06z"
+              clipRule="evenodd"
+            />
+          </svg>
+        )}
+      </button>
+      {expanded && hasResult && (
+        <div className="mt-1.5 rounded-lg overflow-hidden border border-border">
+          <div className="max-h-[400px] overflow-auto">
+            <SyntaxHighlighter
+              language={language}
+              style={oneDark}
+              customStyle={{
+                margin: 0,
+                fontSize: '0.75rem',
+                borderRadius: 0,
+              }}
+              showLineNumbers
+            >
+              {toolCall.result}
+            </SyntaxHighlighter>
+          </div>
+        </div>
+      )}
     </div>
   )
 }
@@ -78,9 +166,9 @@ export function ChatMessage({
 
         {/* Tool calls (shown below assistant messages) */}
         {!isUser && toolCalls && toolCalls.length > 0 && (
-          <div className="mt-2 flex flex-wrap gap-1.5">
+          <div className="mt-2 flex flex-col gap-1.5">
             {toolCalls.map((tc, i) => (
-              <ToolCallBadge key={`${tc.name}-${i}`} toolCall={tc} />
+              <ToolCallItem key={`${tc.name}-${i}`} toolCall={tc} />
             ))}
           </div>
         )}


### PR DESCRIPTION
## Summary
- Tool call badges are now clickable to expand/collapse the full result
- `read_file` results render with language-appropriate syntax highlighting (inferred from file extension)
- `run_shell` results render as bash
- Collapsed by default with a chevron indicator, max-height with scroll when expanded

## Changes
- **`chat-message.tsx`** — Replaced `ToolCallBadge` with `ToolCallItem`: adds expand/collapse toggle, `SyntaxHighlighter` (Prism + oneDark), and file extension → language inference

## Test plan
- [ ] Ask Claude to read a `.ts` file — badge appears, click to expand shows TypeScript-highlighted code
- [ ] Ask Claude to run a shell command — result shows as bash-highlighted output
- [ ] Verify collapse/expand toggle works with chevron animation
- [ ] Long results should scroll within the 400px max-height container
- [ ] Tool calls with empty results should not show the chevron or be expandable

🤖 Generated with [Claude Code](https://claude.com/claude-code)