### PR TITLE
Add cost breakdown by provider and model

### DIFF
--- a/apps/server/src/voice/cost-tracker.ts
+++ b/apps/server/src/voice/cost-tracker.ts
@@ -27,6 +27,13 @@ interface ServiceCosts {
   tts: number
 }
 
+export interface ProviderModelEntry {
+  provider: string
+  model: string
+  cost: number
+  count: number
+}
+
 interface SessionStats {
   interactions: number
   costs: ServiceCosts
@@ -64,6 +71,24 @@ const globalStats: GlobalStats = {
   totalTtsChars: 0,
   sessions: 0,
   startedAt: new Date().toISOString(),
+}
+
+// Per provider+model cost tracking (global, not per-session)
+const providerModelStats = new Map<string, ProviderModelEntry>()
+
+function trackProviderModel(
+  provider: string,
+  model: string,
+  cost: number,
+): void {
+  const key = `${provider}:${model}`
+  const entry = providerModelStats.get(key)
+  if (entry) {
+    entry.cost += cost
+    entry.count++
+  } else {
+    providerModelStats.set(key, { provider, model, cost, count: 1 })
+  }
 }
 
 // Pending costs for the current interaction (accumulated across calls, logged together)
@@ -105,20 +130,30 @@ function ensurePending(sessionId: string): {
   return pending
 }
 
-export function recordSTT(sessionId: string, durationSec: number): number {
+export function recordSTT(
+  sessionId: string,
+  durationSec: number,
+  provider = 'openai',
+  model = 'whisper-1',
+): number {
   const cost = (durationSec / 60) * RATES.whisperPerMinute
   const session = ensureSession(sessionId)
   session.costs.stt += cost
   session.sttDurationSec += durationSec
   globalStats.totalCosts.stt += cost
   globalStats.totalSttDurationSec += durationSec
+  trackProviderModel(provider, model, cost)
 
   const pending = ensurePending(sessionId)
   pending.stt += cost
   return cost
 }
 
-export function recordClaude(sessionId: string, usage: ClaudeUsage): number {
+export function recordClaude(
+  sessionId: string,
+  usage: ClaudeUsage,
+  model = 'claude-sonnet-4-6',
+): number {
   const inputCost = (usage.input_tokens / 1_000_000) * RATES.claudeInputPer1M
   const outputCost = (usage.output_tokens / 1_000_000) * RATES.claudeOutputPer1M
   const cacheReadCost =
@@ -141,19 +176,26 @@ export function recordClaude(sessionId: string, usage: ClaudeUsage): number {
   globalStats.totalClaudeCacheReadTokens += usage.cache_read_input_tokens ?? 0
   globalStats.totalClaudeCacheWriteTokens +=
     usage.cache_creation_input_tokens ?? 0
+  trackProviderModel('anthropic', model, cost)
 
   const pending = ensurePending(sessionId)
   pending.claude += cost
   return cost
 }
 
-export function recordTTS(sessionId: string, charCount: number): number {
+export function recordTTS(
+  sessionId: string,
+  charCount: number,
+  provider = 'openai',
+  model = 'tts-1',
+): number {
   const cost = (charCount / 1_000_000) * RATES.ttsCharsPer1M
   const session = ensureSession(sessionId)
   session.costs.tts += cost
   session.ttsChars += charCount
   globalStats.totalCosts.tts += cost
   globalStats.totalTtsChars += charCount
+  trackProviderModel(provider, model, cost)
 
   const pending = ensurePending(sessionId)
   pending.tts += cost
@@ -208,6 +250,10 @@ export function getStats() {
     costs: { ...s.costs },
   }))
 
+  const byProviderModel = Array.from(providerModelStats.values()).sort(
+    (a, b) => b.cost - a.cost,
+  )
+
   return {
     totalInteractions: globalStats.totalInteractions,
     totalCost,
@@ -221,6 +267,7 @@ export function getStats() {
       claudeCacheWriteTokens: globalStats.totalClaudeCacheWriteTokens,
       ttsChars: globalStats.totalTtsChars,
     },
+    byProviderModel,
     sessions: sessionSummaries,
     activeSessions: sessionData.size,
     startedAt: globalStats.startedAt,

--- a/apps/server/src/ws/audio.ts
+++ b/apps/server/src/ws/audio.ts
@@ -20,7 +20,7 @@ import {
   recordSTT,
   recordTTS,
 } from '../voice/cost-tracker.js'
-import { transcribe } from '../voice/stt.js'
+import { getSTTProvider, transcribe } from '../voice/stt.js'
 import { filterForTTS } from '../voice/text-filter.js'
 import { getTTSProvider } from '../voice/tts.js'
 
@@ -294,7 +294,8 @@ async function handleControl(
       try {
         const result = await transcribe(combined)
         userText = result.text
-        recordSTT(sessionId, result.durationSec)
+        const sttProvider = getSTTProvider()
+        recordSTT(sessionId, result.durationSec, sttProvider.name, 'whisper-1')
       } catch (err) {
         const message = err instanceof Error ? err.message : 'Unknown error'
         console.error(`[ws] stt error  ${message}`)
@@ -362,7 +363,7 @@ async function handleControl(
           },
         )
 
-        recordClaude(sessionId, response.usage)
+        recordClaude(sessionId, response.usage, response.model)
 
         // Persist assistant message
         if (conversationId) {
@@ -400,8 +401,8 @@ async function handleControl(
           send(ws, { type: 'synthesizing' })
 
           try {
-            recordTTS(sessionId, spokenText.length)
             const ttsProvider = await getTTSProvider()
+            recordTTS(sessionId, spokenText.length, ttsProvider.name, 'tts-1')
             const audioBuffer = await ttsProvider.synthesize(spokenText)
 
             if (signal.aborted) {

--- a/apps/web/app/routes/costs.tsx
+++ b/apps/web/app/routes/costs.tsx
@@ -27,6 +27,13 @@ interface SessionSummary {
   costs: ServiceCosts
 }
 
+interface ProviderModelEntry {
+  provider: string
+  model: string
+  cost: number
+  count: number
+}
+
 interface Stats {
   totalInteractions: number
   totalCost: number
@@ -40,6 +47,7 @@ interface Stats {
     claudeCacheWriteTokens: number
     ttsChars: number
   }
+  byProviderModel: ProviderModelEntry[]
   sessions: SessionSummary[]
   activeSessions: number
   startedAt: string
@@ -68,22 +76,43 @@ function formatDuration(seconds: number): string {
   return `${mins}m ${secs.toFixed(0)}s`
 }
 
+function providerColor(provider: string): string {
+  switch (provider) {
+    case 'anthropic':
+      return 'bg-violet-500'
+    case 'openai':
+      return 'bg-emerald-500'
+    case 'google':
+      return 'bg-blue-500'
+    case 'local':
+    case 'piper':
+      return 'bg-gray-500'
+    default:
+      return 'bg-amber-500'
+  }
+}
+
 function CostBar({
   label,
   cost,
   total,
   color,
+  detail,
 }: {
   label: string
   cost: number
   total: number
   color: string
+  detail?: string
 }) {
   const pct = total > 0 ? (cost / total) * 100 : 0
   return (
     <div className="space-y-1">
       <div className="flex items-center justify-between text-sm">
-        <span className="text-muted-foreground">{label}</span>
+        <span className="text-muted-foreground">
+          {label}
+          {detail && <span className="ml-2 text-xs opacity-60">{detail}</span>}
+        </span>
         <span className="font-mono font-medium text-foreground">
           {formatCost(cost)}
         </span>
@@ -231,6 +260,32 @@ export default function Costs() {
                 />
               </CardContent>
             </Card>
+
+            {/* Cost by Provider & Model */}
+            {stats.byProviderModel.length > 0 && (
+              <Card>
+                <CardHeader>
+                  <CardTitle className="text-base">
+                    Cost by Provider & Model
+                  </CardTitle>
+                  <CardDescription>
+                    Breakdown by AI provider and model
+                  </CardDescription>
+                </CardHeader>
+                <CardContent className="space-y-4">
+                  {stats.byProviderModel.map((entry) => (
+                    <CostBar
+                      key={`${entry.provider}:${entry.model}`}
+                      label={`${entry.provider} / ${entry.model}`}
+                      cost={entry.cost}
+                      total={stats.totalCost}
+                      color={providerColor(entry.provider)}
+                      detail={`${formatNumber(entry.count)} calls`}
+                    />
+                  ))}
+                </CardContent>
+              </Card>
+            )}
 
             {/* Usage Details */}
             <Card>


### PR DESCRIPTION
## Summary
- Track API costs per provider+model combination (e.g. `anthropic/claude-haiku-4-5`, `openai/whisper-1`, `google/tts-1`) in the cost tracker
- `recordSTT`, `recordClaude`, and `recordTTS` now accept optional provider/model params (backward-compatible)
- New "Cost by Provider & Model" card on the costs page showing cost bars sorted by spend, with call counts and provider-colored bars

## Test plan
- [ ] Start a voice session and make a few interactions
- [ ] Visit `/costs` and verify the new "Cost by Provider & Model" card appears
- [ ] Confirm entries show correct provider/model labels (e.g. `anthropic / claude-haiku-4-5-20251001`)
- [ ] Verify call counts increment with each interaction
- [ ] Confirm the existing "Cost by Service" card still works unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)