### PR TITLE
Add environment capability discovery and Docker dev tools

### DIFF
--- a/apps/server/Dockerfile
+++ b/apps/server/Dockerfile
@@ -28,8 +28,18 @@ FROM node:22-slim AS runner
 
 RUN corepack enable && corepack prepare pnpm@9.15.0 --activate
 
-# Install curl for healthcheck and git for Claude tool execution
-RUN apt-get update && apt-get install -y --no-install-recommends curl git && rm -rf /var/lib/apt/lists/*
+# Install curl for healthcheck, git for Claude tool execution, and dev tools for shell access
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    curl \
+    git \
+    jq \
+    less \
+    make \
+    python3 \
+    ripgrep \
+    tree \
+    wget \
+  && rm -rf /var/lib/apt/lists/*
 
 # Create non-root user
 RUN addgroup --system --gid 1001 nodejs && adduser --system --uid 1001 appuser

--- a/apps/server/Dockerfile.dev
+++ b/apps/server/Dockerfile.dev
@@ -1,6 +1,16 @@
 FROM node:22-slim
 
-RUN apt-get update && apt-get install -y --no-install-recommends git && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    curl \
+    git \
+    jq \
+    less \
+    make \
+    python3 \
+    ripgrep \
+    tree \
+    wget \
+  && rm -rf /var/lib/apt/lists/*
 RUN corepack enable && corepack prepare pnpm@9.15.0 --activate
 
 WORKDIR /app

--- a/apps/server/src/voice/claude.ts
+++ b/apps/server/src/voice/claude.ts
@@ -6,6 +6,8 @@ import { promisify } from 'node:util'
 const execAsync = promisify(exec)
 import Anthropic from '@anthropic-ai/sdk'
 
+import { discoverEnvironment } from './environment.js'
+
 let client: Anthropic | null = null
 
 function getClient(): Anthropic {
@@ -135,13 +137,22 @@ function isCommandBlocked(cmd: string): string | null {
   }
   return null
 }
-const SYSTEM_PROMPT = `You are a hands-free voice coding assistant called Voice Claude. You run as a web app that the user accesses from their phone or computer. You can hear them speak through their microphone — their speech is transcribed and sent to you. Your responses are spoken back to them via text-to-speech. This is a live, real-time voice conversation.
+let _systemPrompt: string | null = null
+
+async function getSystemPrompt(): Promise<string> {
+  if (_systemPrompt !== null) {
+    return _systemPrompt
+  }
+
+  const envCapabilities = await discoverEnvironment()
+
+  _systemPrompt = `You are a hands-free voice coding assistant called Voice Claude. You run as a web app that the user accesses from their phone or computer. You can hear them speak through their microphone — their speech is transcribed and sent to you. Your responses are spoken back to them via text-to-speech. This is a live, real-time voice conversation.
 
 When the user says things like "can you hear me" or "are you there", respond naturally — you can hear them. If they ask what you are, explain that you're a voice interface for Claude that can help with coding tasks hands-free.
 
 Input is speech-to-text — interpret generously despite transcription errors.
 
-You have tools for files, shell commands, and git. Use them as needed.
+You have tools for files, shell commands, and git. Use them as needed.${envCapabilities}
 
 VOICE RULES (responses are spoken via TTS):
 - 100 words max. Two to three sentences typical.
@@ -151,6 +162,9 @@ VOICE RULES (responses are spoken via TTS):
 - If the user asks for details, give slightly more but still stay concise.
 
 Working directory: ${WORK_DIR}`
+
+  return _systemPrompt
+}
 const tools: Anthropic.Tool[] = [
   {
     name: 'run_shell',
@@ -349,7 +363,7 @@ export async function chat(
           system: [
             {
               type: 'text',
-              text: SYSTEM_PROMPT,
+              text: await getSystemPrompt(),
               cache_control: { type: 'ephemeral' },
             },
           ],

--- a/apps/server/src/voice/environment.ts
+++ b/apps/server/src/voice/environment.ts
@@ -1,0 +1,67 @@
+import { exec } from 'node:child_process'
+import { promisify } from 'node:util'
+
+const execAsync = promisify(exec)
+
+interface ToolInfo {
+  binary: string
+  description: string
+}
+
+const KNOWN_TOOLS: ToolInfo[] = [
+  { binary: 'git', description: 'version control' },
+  { binary: 'curl', description: 'HTTP requests' },
+  { binary: 'wget', description: 'file downloads' },
+  { binary: 'jq', description: 'JSON processing' },
+  { binary: 'rg', description: 'fast code search (ripgrep)' },
+  { binary: 'tree', description: 'directory visualization' },
+  { binary: 'make', description: 'build automation' },
+  { binary: 'python3', description: 'Python scripting' },
+  { binary: 'node', description: 'Node.js runtime' },
+  { binary: 'gh', description: 'GitHub CLI' },
+  { binary: 'docker', description: 'container management' },
+  { binary: 'less', description: 'file paging' },
+]
+
+let cachedCapabilities: string | null = null
+
+async function checkBinary(binary: string): Promise<boolean> {
+  try {
+    await execAsync(`which ${binary}`)
+    return true
+  } catch {
+    return false
+  }
+}
+
+export async function discoverEnvironment(): Promise<string> {
+  if (cachedCapabilities !== null) {
+    return cachedCapabilities
+  }
+
+  const results = await Promise.all(
+    KNOWN_TOOLS.map(async (tool) => ({
+      ...tool,
+      available: await checkBinary(tool.binary),
+    })),
+  )
+
+  const available = results.filter((r) => r.available)
+
+  if (available.length === 0) {
+    cachedCapabilities = ''
+    return cachedCapabilities
+  }
+
+  const toolList = available
+    .map((t) => `${t.binary} (${t.description})`)
+    .join(', ')
+
+  cachedCapabilities = `\nAvailable CLI tools: ${toolList}.`
+
+  console.log(
+    `[environment] discovered tools: ${available.map((t) => t.binary).join(', ')}`,
+  )
+
+  return cachedCapabilities
+}


### PR DESCRIPTION
## Summary
- Installs a curated set of dev tools (`jq`, `ripgrep`, `tree`, `make`, `python3`, `wget`, `less`) in both production and dev server Docker images
- Adds startup-time environment capability discovery that probes for available CLI binaries and injects them into Claude's system prompt
- Claude now knows what tools are available regardless of whether it's running in Docker or on bare metal

## How it works
A new `environment.ts` module checks for known binaries via `which` at first request, caches the results, and appends an `Available CLI tools: ...` line to the system prompt. The discovery runs once and is cached for the lifetime of the process.

## Test plan
- [ ] `pnpm dev` — check server logs for `[environment] discovered tools: ...` on first voice request
- [ ] `docker compose up --build` — verify the log output shows the installed tools
- [ ] Ask Claude "what tools do you have available?" — should answer based on discovered tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)