### PR TITLE
Add rolling cost history with time period selector

### DIFF
--- a/apps/server/src/storage/costs.ts
+++ b/apps/server/src/storage/costs.ts
@@ -1,0 +1,140 @@
+// Persistent cost history — each finalized interaction is appended as a JSONL record.
+// Supports querying by time range for rolling cost views.
+
+import { appendFile, mkdir, readFile } from 'node:fs/promises'
+import { join } from 'node:path'
+
+const DATA_DIR = join(process.cwd(), 'data', 'costs')
+const HISTORY_FILE = join(DATA_DIR, 'history.jsonl')
+
+export interface CostRecord {
+  timestamp: string
+  sessionId: string
+  costs: { stt: number; claude: number; tts: number }
+  usage: {
+    sttDurationSec: number
+    claudeInputTokens: number
+    claudeOutputTokens: number
+    claudeCacheReadTokens: number
+    claudeCacheWriteTokens: number
+    ttsChars: number
+  }
+  providers: Array<{ provider: string; model: string; cost: number }>
+}
+
+export interface AggregatedCosts {
+  totalInteractions: number
+  totalCost: number
+  avgCostPerInteraction: number
+  costBreakdown: { stt: number; claude: number; tts: number }
+  usage: {
+    sttDurationSec: number
+    claudeInputTokens: number
+    claudeOutputTokens: number
+    claudeCacheReadTokens: number
+    claudeCacheWriteTokens: number
+    ttsChars: number
+  }
+  byProviderModel: Array<{
+    provider: string
+    model: string
+    cost: number
+    count: number
+  }>
+  periodStart: string
+  periodEnd: string
+}
+
+let initialized = false
+
+async function ensureDir() {
+  if (initialized) return
+  await mkdir(DATA_DIR, { recursive: true })
+  initialized = true
+}
+
+export async function appendCostRecord(record: CostRecord): Promise<void> {
+  await ensureDir()
+  await appendFile(HISTORY_FILE, `${JSON.stringify(record)}\n`)
+}
+
+async function readAllRecords(): Promise<CostRecord[]> {
+  await ensureDir()
+  let content: string
+  try {
+    content = (await readFile(HISTORY_FILE, 'utf-8')).trim()
+  } catch {
+    return []
+  }
+  if (!content) return []
+  return content.split('\n').map((line) => JSON.parse(line) as CostRecord)
+}
+
+export async function queryCosts(
+  from: string,
+  to: string,
+): Promise<AggregatedCosts> {
+  const records = await readAllRecords()
+  const fromTime = new Date(from).getTime()
+  const toTime = new Date(to).getTime()
+
+  const filtered = records.filter((r) => {
+    const t = new Date(r.timestamp).getTime()
+    return t >= fromTime && t <= toTime
+  })
+
+  const costBreakdown = { stt: 0, claude: 0, tts: 0 }
+  const usage = {
+    sttDurationSec: 0,
+    claudeInputTokens: 0,
+    claudeOutputTokens: 0,
+    claudeCacheReadTokens: 0,
+    claudeCacheWriteTokens: 0,
+    ttsChars: 0,
+  }
+  const providerMap = new Map<
+    string,
+    { provider: string; model: string; cost: number; count: number }
+  >()
+
+  for (const r of filtered) {
+    costBreakdown.stt += r.costs.stt
+    costBreakdown.claude += r.costs.claude
+    costBreakdown.tts += r.costs.tts
+
+    usage.sttDurationSec += r.usage.sttDurationSec
+    usage.claudeInputTokens += r.usage.claudeInputTokens
+    usage.claudeOutputTokens += r.usage.claudeOutputTokens
+    usage.claudeCacheReadTokens += r.usage.claudeCacheReadTokens
+    usage.claudeCacheWriteTokens += r.usage.claudeCacheWriteTokens
+    usage.ttsChars += r.usage.ttsChars
+
+    for (const p of r.providers) {
+      const key = `${p.provider}:${p.model}`
+      const existing = providerMap.get(key)
+      if (existing) {
+        existing.cost += p.cost
+        existing.count++
+      } else {
+        providerMap.set(key, { ...p, count: 1 })
+      }
+    }
+  }
+
+  const totalCost = costBreakdown.stt + costBreakdown.claude + costBreakdown.tts
+  const totalInteractions = filtered.length
+
+  return {
+    totalInteractions,
+    totalCost,
+    avgCostPerInteraction:
+      totalInteractions > 0 ? totalCost / totalInteractions : 0,
+    costBreakdown,
+    usage,
+    byProviderModel: Array.from(providerMap.values()).sort(
+      (a, b) => b.cost - a.cost,
+    ),
+    periodStart: from,
+    periodEnd: to,
+  }
+}

--- a/apps/server/src/trpc/router.ts
+++ b/apps/server/src/trpc/router.ts
@@ -6,6 +6,7 @@ import {
   listConversations,
   updateConversationTitle,
 } from '../storage/conversations.js'
+import { queryCosts } from '../storage/costs.js'
 import { getStats } from '../voice/cost-tracker.js'
 import { createRouter, publicProcedure } from './init.js'
 
@@ -24,6 +25,11 @@ export const appRouter = createRouter({
   stats: publicProcedure.query(() => {
     return getStats()
   }),
+  costHistory: publicProcedure
+    .input(z.object({ from: z.string(), to: z.string() }))
+    .query(({ input }) => {
+      return queryCosts(input.from, input.to)
+    }),
   conversations: createRouter({
     list: publicProcedure.query(() => {
       return listConversations()

--- a/apps/server/src/voice/cost-tracker.ts
+++ b/apps/server/src/voice/cost-tracker.ts
@@ -1,5 +1,7 @@
 // Per-interaction cost tracking for STT, Claude, and TTS API calls.
 
+import { appendCostRecord } from '../storage/costs.js'
+
 // Pricing rates
 const RATES = {
   // Whisper: $0.006 per minute of audio
@@ -97,6 +99,25 @@ const pendingCosts = new Map<
   { stt: number; claude: number; tts: number }
 >()
 
+// Pending usage metrics for the current interaction (for persistence)
+const pendingUsage = new Map<
+  string,
+  {
+    sttDurationSec: number
+    claudeInputTokens: number
+    claudeOutputTokens: number
+    claudeCacheReadTokens: number
+    claudeCacheWriteTokens: number
+    ttsChars: number
+  }
+>()
+
+// Pending provider entries for the current interaction (for persistence)
+const pendingProviders = new Map<
+  string,
+  Array<{ provider: string; model: string; cost: number }>
+>()
+
 function ensureSession(sessionId: string): SessionStats {
   if (!sessionData.has(sessionId)) {
     globalStats.sessions++
@@ -130,6 +151,36 @@ function ensurePending(sessionId: string): {
   return pending
 }
 
+function ensurePendingUsage(sessionId: string) {
+  let usage = pendingUsage.get(sessionId)
+  if (!usage) {
+    usage = {
+      sttDurationSec: 0,
+      claudeInputTokens: 0,
+      claudeOutputTokens: 0,
+      claudeCacheReadTokens: 0,
+      claudeCacheWriteTokens: 0,
+      ttsChars: 0,
+    }
+    pendingUsage.set(sessionId, usage)
+  }
+  return usage
+}
+
+function addPendingProvider(
+  sessionId: string,
+  provider: string,
+  model: string,
+  cost: number,
+) {
+  let providers = pendingProviders.get(sessionId)
+  if (!providers) {
+    providers = []
+    pendingProviders.set(sessionId, providers)
+  }
+  providers.push({ provider, model, cost })
+}
+
 export function recordSTT(
   sessionId: string,
   durationSec: number,
@@ -146,6 +197,9 @@ export function recordSTT(
 
   const pending = ensurePending(sessionId)
   pending.stt += cost
+  const pu = ensurePendingUsage(sessionId)
+  pu.sttDurationSec += durationSec
+  addPendingProvider(sessionId, provider, model, cost)
   return cost
 }
 
@@ -180,6 +234,12 @@ export function recordClaude(
 
   const pending = ensurePending(sessionId)
   pending.claude += cost
+  const pu = ensurePendingUsage(sessionId)
+  pu.claudeInputTokens += usage.input_tokens
+  pu.claudeOutputTokens += usage.output_tokens
+  pu.claudeCacheReadTokens += usage.cache_read_input_tokens ?? 0
+  pu.claudeCacheWriteTokens += usage.cache_creation_input_tokens ?? 0
+  addPendingProvider(sessionId, 'anthropic', model, cost)
   return cost
 }
 
@@ -199,6 +259,9 @@ export function recordTTS(
 
   const pending = ensurePending(sessionId)
   pending.tts += cost
+  const pu = ensurePendingUsage(sessionId)
+  pu.ttsChars += charCount
+  addPendingProvider(sessionId, provider, model, cost)
   return cost
 }
 
@@ -220,7 +283,27 @@ export function finalizeInteraction(sessionId: string): void {
       `total=$${total.toFixed(4)} | cumulative=$${(globalStats.totalCosts.stt + globalStats.totalCosts.claude + globalStats.totalCosts.tts).toFixed(4)}`,
   )
 
+  // Persist to disk for historical queries
+  const usage = pendingUsage.get(sessionId) ?? {
+    sttDurationSec: 0,
+    claudeInputTokens: 0,
+    claudeOutputTokens: 0,
+    claudeCacheReadTokens: 0,
+    claudeCacheWriteTokens: 0,
+    ttsChars: 0,
+  }
+  const providers = pendingProviders.get(sessionId) ?? []
+  appendCostRecord({
+    timestamp: new Date().toISOString(),
+    sessionId,
+    costs: { ...pending },
+    usage: { ...usage },
+    providers,
+  }).catch((err) => console.error('[cost] failed to persist record:', err))
+
   pendingCosts.delete(sessionId)
+  pendingUsage.delete(sessionId)
+  pendingProviders.delete(sessionId)
 }
 
 /**
@@ -230,6 +313,8 @@ export function finalizeInteraction(sessionId: string): void {
 export function cleanupSession(sessionId: string): void {
   sessionData.delete(sessionId)
   pendingCosts.delete(sessionId)
+  pendingUsage.delete(sessionId)
+  pendingProviders.delete(sessionId)
 }
 
 export function getStats() {

--- a/apps/web/app/routes/costs.tsx
+++ b/apps/web/app/routes/costs.tsx
@@ -34,7 +34,7 @@ interface ProviderModelEntry {
   count: number
 }
 
-interface Stats {
+interface CostHistory {
   totalInteractions: number
   totalCost: number
   avgCostPerInteraction: number
@@ -48,9 +48,78 @@ interface Stats {
     ttsChars: number
   }
   byProviderModel: ProviderModelEntry[]
+  periodStart: string
+  periodEnd: string
+}
+
+interface SessionStats {
   sessions: SessionSummary[]
   activeSessions: number
-  startedAt: string
+}
+
+type Period = 'today' | '7d' | '30d' | 'all'
+
+const PERIODS: { key: Period; label: string }[] = [
+  { key: 'today', label: 'Today' },
+  { key: '7d', label: '7 Days' },
+  { key: '30d', label: '30 Days' },
+  { key: 'all', label: 'All Time' },
+]
+
+function getPeriodRange(period: Period): { from: string; to: string } {
+  const now = new Date()
+  const endOfDay = new Date(
+    now.getFullYear(),
+    now.getMonth(),
+    now.getDate(),
+    23,
+    59,
+    59,
+    999,
+  )
+  const to = endOfDay.toISOString()
+
+  switch (period) {
+    case 'today': {
+      const startOfDay = new Date(
+        now.getFullYear(),
+        now.getMonth(),
+        now.getDate(),
+      )
+      return { from: startOfDay.toISOString(), to }
+    }
+    case '7d': {
+      const start = new Date(
+        now.getFullYear(),
+        now.getMonth(),
+        now.getDate() - 6,
+      )
+      return { from: start.toISOString(), to }
+    }
+    case '30d': {
+      const start = new Date(
+        now.getFullYear(),
+        now.getMonth(),
+        now.getDate() - 29,
+      )
+      return { from: start.toISOString(), to }
+    }
+    case 'all':
+      return { from: '2000-01-01T00:00:00.000Z', to }
+  }
+}
+
+function periodLabel(period: Period): string {
+  switch (period) {
+    case 'today':
+      return new Date().toLocaleDateString()
+    case '7d':
+      return 'Last 7 days'
+    case '30d':
+      return 'Last 30 days'
+    case 'all':
+      return 'All time'
+  }
 }
 
 export function meta() {
@@ -129,33 +198,44 @@ function CostBar({
 
 export default function Costs() {
   const { wsConfig } = useOutletContext<RootContext>()
-  const [stats, setStats] = useState<Stats | null>(null)
+  const [history, setHistory] = useState<CostHistory | null>(null)
+  const [sessionStats, setSessionStats] = useState<SessionStats | null>(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
+  const [period, setPeriod] = useState<Period>('today')
 
   const trpc = useMemo(() => {
     if (typeof window === 'undefined' || !wsConfig) return null
     return getClientTRPC(wsConfig.port)
   }, [wsConfig])
 
-  const fetchStats = useCallback(async () => {
+  const fetchData = useCallback(async () => {
     if (!trpc) return
     try {
-      const data = await trpc.stats.query()
-      setStats(data)
+      const range = getPeriodRange(period)
+      const [historyData, statsData] = await Promise.all([
+        trpc.costHistory.query(range),
+        trpc.stats.query(),
+      ])
+      setHistory(historyData)
+      setSessionStats({
+        sessions: statsData.sessions,
+        activeSessions: statsData.activeSessions,
+      })
       setError(null)
     } catch (e) {
       setError(e instanceof Error ? e.message : 'Failed to fetch stats')
     } finally {
       setLoading(false)
     }
-  }, [trpc])
+  }, [trpc, period])
 
   useEffect(() => {
-    fetchStats()
-    const interval = setInterval(fetchStats, 10_000)
+    setLoading(true)
+    fetchData()
+    const interval = setInterval(fetchData, 10_000)
     return () => clearInterval(interval)
-  }, [fetchStats])
+  }, [fetchData])
 
   return (
     <div className="min-h-screen bg-background">
@@ -185,14 +265,30 @@ export default function Costs() {
             Costs
           </h1>
         </div>
-        {stats && (
-          <span className="text-xs text-muted-foreground">
-            Since {new Date(stats.startedAt).toLocaleDateString()}
-          </span>
-        )}
+        <span className="text-xs text-muted-foreground">
+          {periodLabel(period)}
+        </span>
       </header>
 
       <div className="max-w-2xl mx-auto p-4 space-y-4">
+        {/* Period Selector */}
+        <div className="flex gap-1 p-1 rounded-lg bg-muted">
+          {PERIODS.map((p) => (
+            <button
+              key={p.key}
+              type="button"
+              onClick={() => setPeriod(p.key)}
+              className={`flex-1 px-3 py-1.5 text-sm font-medium rounded-md transition-colors ${
+                period === p.key
+                  ? 'bg-background text-foreground shadow-sm'
+                  : 'text-muted-foreground hover:text-foreground'
+              }`}
+            >
+              {p.label}
+            </button>
+          ))}
+        </div>
+
         {loading && (
           <div className="flex items-center justify-center py-20">
             <div className="w-6 h-6 border-2 border-primary border-t-transparent rounded-full animate-spin" />
@@ -207,26 +303,30 @@ export default function Costs() {
           </Card>
         )}
 
-        {stats && !loading && (
+        {history && !loading && (
           <>
             {/* Total Cost */}
             <Card>
               <CardHeader className="pb-2">
                 <CardDescription>Total Spend</CardDescription>
                 <CardTitle className="text-3xl font-mono">
-                  {formatCost(stats.totalCost)}
+                  {formatCost(history.totalCost)}
                 </CardTitle>
               </CardHeader>
               <CardContent>
                 <div className="flex gap-4 text-sm text-muted-foreground">
-                  <span>{stats.totalInteractions} interactions</span>
+                  <span>{history.totalInteractions} interactions</span>
+                  {sessionStats && (
+                    <>
+                      <span className="text-border">|</span>
+                      <span>
+                        {sessionStats.activeSessions} active session
+                        {sessionStats.activeSessions !== 1 ? 's' : ''}
+                      </span>
+                    </>
+                  )}
                   <span className="text-border">|</span>
-                  <span>
-                    {stats.activeSessions} active session
-                    {stats.activeSessions !== 1 ? 's' : ''}
-                  </span>
-                  <span className="text-border">|</span>
-                  <span>{formatCost(stats.avgCostPerInteraction)} avg</span>
+                  <span>{formatCost(history.avgCostPerInteraction)} avg</span>
                 </div>
               </CardContent>
             </Card>
@@ -242,27 +342,27 @@ export default function Costs() {
               <CardContent className="space-y-4">
                 <CostBar
                   label="Claude (Anthropic)"
-                  cost={stats.costBreakdown.claude}
-                  total={stats.totalCost}
+                  cost={history.costBreakdown.claude}
+                  total={history.totalCost}
                   color="bg-violet-500"
                 />
                 <CostBar
                   label="Speech-to-Text (OpenAI Whisper)"
-                  cost={stats.costBreakdown.stt}
-                  total={stats.totalCost}
+                  cost={history.costBreakdown.stt}
+                  total={history.totalCost}
                   color="bg-emerald-500"
                 />
                 <CostBar
                   label="Text-to-Speech (OpenAI TTS)"
-                  cost={stats.costBreakdown.tts}
-                  total={stats.totalCost}
+                  cost={history.costBreakdown.tts}
+                  total={history.totalCost}
                   color="bg-amber-500"
                 />
               </CardContent>
             </Card>
 
             {/* Cost by Provider & Model */}
-            {stats.byProviderModel.length > 0 && (
+            {history.byProviderModel.length > 0 && (
               <Card>
                 <CardHeader>
                   <CardTitle className="text-base">
@@ -273,12 +373,12 @@ export default function Costs() {
                   </CardDescription>
                 </CardHeader>
                 <CardContent className="space-y-4">
-                  {stats.byProviderModel.map((entry) => (
+                  {history.byProviderModel.map((entry) => (
                     <CostBar
                       key={`${entry.provider}:${entry.model}`}
                       label={`${entry.provider} / ${entry.model}`}
                       cost={entry.cost}
-                      total={stats.totalCost}
+                      total={history.totalCost}
                       color={providerColor(entry.provider)}
                       detail={`${formatNumber(entry.count)} calls`}
                     />
@@ -299,7 +399,7 @@ export default function Costs() {
                     <div>
                       <p className="text-muted-foreground">STT Duration</p>
                       <p className="font-mono font-medium">
-                        {formatDuration(stats.usage.sttDurationSec)}
+                        {formatDuration(history.usage.sttDurationSec)}
                       </p>
                     </div>
                     <div>
@@ -307,7 +407,7 @@ export default function Costs() {
                         Claude Input Tokens
                       </p>
                       <p className="font-mono font-medium">
-                        {formatNumber(stats.usage.claudeInputTokens)}
+                        {formatNumber(history.usage.claudeInputTokens)}
                       </p>
                     </div>
                     <div>
@@ -315,7 +415,7 @@ export default function Costs() {
                         Claude Output Tokens
                       </p>
                       <p className="font-mono font-medium">
-                        {formatNumber(stats.usage.claudeOutputTokens)}
+                        {formatNumber(history.usage.claudeOutputTokens)}
                       </p>
                     </div>
                   </div>
@@ -323,13 +423,13 @@ export default function Costs() {
                     <div>
                       <p className="text-muted-foreground">TTS Characters</p>
                       <p className="font-mono font-medium">
-                        {formatNumber(stats.usage.ttsChars)}
+                        {formatNumber(history.usage.ttsChars)}
                       </p>
                     </div>
                     <div>
                       <p className="text-muted-foreground">Cache Read Tokens</p>
                       <p className="font-mono font-medium">
-                        {formatNumber(stats.usage.claudeCacheReadTokens)}
+                        {formatNumber(history.usage.claudeCacheReadTokens)}
                       </p>
                     </div>
                     <div>
@@ -337,7 +437,7 @@ export default function Costs() {
                         Cache Write Tokens
                       </p>
                       <p className="font-mono font-medium">
-                        {formatNumber(stats.usage.claudeCacheWriteTokens)}
+                        {formatNumber(history.usage.claudeCacheWriteTokens)}
                       </p>
                     </div>
                   </div>
@@ -346,18 +446,19 @@ export default function Costs() {
             </Card>
 
             {/* Active Sessions */}
-            {stats.sessions.length > 0 && (
+            {sessionStats && sessionStats.sessions.length > 0 && (
               <Card>
                 <CardHeader>
                   <CardTitle className="text-base">Active Sessions</CardTitle>
                   <CardDescription>
-                    {stats.sessions.length} session
-                    {stats.sessions.length !== 1 ? 's' : ''} with tracked costs
+                    {sessionStats.sessions.length} session
+                    {sessionStats.sessions.length !== 1 ? 's' : ''} with tracked
+                    costs
                   </CardDescription>
                 </CardHeader>
                 <CardContent>
                   <div className="space-y-3">
-                    {stats.sessions.map((session) => (
+                    {sessionStats.sessions.map((session) => (
                       <div
                         key={session.sessionId}
                         className="flex items-center justify-between py-2 border-b border-border last:border-0"
@@ -398,7 +499,7 @@ export default function Costs() {
             <div className="flex justify-center pb-4">
               <button
                 type="button"
-                onClick={fetchStats}
+                onClick={fetchData}
                 className="text-xs text-muted-foreground hover:text-foreground transition-colors"
               >
                 Auto-refreshes every 10s


### PR DESCRIPTION
## Summary
- Persist each finalized interaction as a timestamped JSONL record (`data/costs/history.jsonl`) so cost data survives server restarts
- Add `costHistory` tRPC endpoint accepting `{ from, to }` ISO timestamps to query costs over a time range
- Replace session-only costs page with a time period selector (Today, 7 Days, 30 Days, All Time) defaulting to **Today**

## Test plan
- [ ] Start the server and make a few voice interactions
- [ ] Visit `/costs` and verify the period selector appears with "Today" active
- [ ] Switch between periods and confirm data updates
- [ ] Restart the server and verify historical costs persist
- [ ] Confirm active sessions card still shows live session data

🤖 Generated with [Claude Code](https://claude.com/claude-code)