### PR TITLE
feat: systemd daemon, voice-claude CLI, and bare-metal install fixes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -55,9 +55,10 @@ OPENAI_API_KEY=sk-...
 # PIPER_VOICE=                                # speaker name for multi-speaker models
 
 # Working directory for Claude tool execution
-# This is the host directory that gets mounted into the container at /workspace.
-# Claude's tools (shell, file read) operate inside this directory.
-# WORK_DIR=~/projects
+# Bare metal: the directory Claude's tools (shell, file read/write) will operate in.
+# Defaults to $HOME if not set (install.sh sets this automatically).
+# Docker: this is the host directory mounted into the container at /workspace.
+# WORK_DIR=/home/youruser
 
 # Conversation history storage (production Docker only, defaults to ./data/conversations)
 # CONVERSATIONS_DIR=./data/conversations

--- a/README.md
+++ b/README.md
@@ -1,0 +1,212 @@
+# voice-claude
+
+A hands-free voice interface for Claude. Talk to Claude through Bluetooth earbuds on your phone while your hands are busy, and have Claude working on code, managing repos, and talking back.
+
+```
+Earbuds Mic → Speech-to-Text → Claude API (with tool use) → Text-to-Speech → Earbuds Speaker
+```
+
+## Prerequisites
+
+- **Node.js 22+** (the install script will set this up for you on Debian/Ubuntu)
+- **pnpm 9.15+** (installed automatically via corepack)
+- **API keys**: Anthropic (required), OpenAI (required for default STT/TTS)
+- **Docker** (only if using Docker-based deployment)
+
+## Quick Start (Bare Metal)
+
+```bash
+git clone https://github.com/evanstern/voice-claude.git
+cd voice-claude
+
+# Edit .env with your API keys before installing
+cp .env.example .env
+vim .env
+
+# Install everything and start the service
+./scripts/install.sh
+```
+
+The install script sets up Node.js, builds the project, installs a systemd service, and starts it automatically. The web app will be at `http://localhost:3000` and the API server at `http://localhost:4000`.
+
+After installation, manage the service with:
+
+```bash
+voice-claude status            # check if running
+voice-claude logs -f           # follow logs
+voice-claude restart           # restart after .env changes
+voice-claude stop              # stop the service
+voice-claude start             # start it back up
+voice-claude update            # git pull, rebuild, restart
+voice-claude uninstall         # remove service and CLI
+```
+
+## Configuration
+
+The install script creates a `.env` file from `.env.example`. At minimum, you need to set:
+
+```bash
+ANTHROPIC_API_KEY=sk-ant-...   # Required - Claude API access
+OPENAI_API_KEY=sk-...          # Required for default Whisper STT and OpenAI TTS
+```
+
+### All Environment Variables
+
+| Variable | Default | Description |
+|---|---|---|
+| `PORT` | `4000` | API server port |
+| `WEB_PORT` | `3000` | Web app port |
+| `SERVER_URL` | `http://localhost:4000` | Internal URL the web app uses to reach the server |
+| `LOG_LEVEL` | `debug` (dev) / `info` (prod) | Logging verbosity: `debug`, `info`, `warn`, `error` |
+| `ANTHROPIC_API_KEY` | -- | **Required.** Anthropic API key for Claude |
+| `OPENAI_API_KEY` | -- | **Required** (when using OpenAI STT/TTS) |
+| `AI_PROVIDER` | `anthropic` | `anthropic` (direct API) or `claude-code` (Claude Code CLI) |
+| `CLAUDE_MODEL` | `auto` | Model routing: `auto`, `sonnet`, or `haiku` |
+| `STT_PROVIDER` | `openai` | Speech-to-text: `openai` or `local` |
+| `TTS_PROVIDER` | `openai` | Text-to-speech: `openai`, `google`, or `piper` |
+| `TTS_VOICE` | `nova` | OpenAI TTS voice name |
+| `WORK_DIR` | `./workspace` | Host directory mounted for Claude tool execution |
+| `BEHIND_PROXY` | `false` | Set `true` when behind a reverse proxy (Traefik, nginx) |
+| `CONVERSATIONS_DIR` | `./data/conversations` | Where conversation history is stored (production Docker) |
+
+### TTS Provider Options
+
+**OpenAI TTS** (default) -- Uses the OpenAI API. Set `TTS_VOICE` to change the voice (default: `nova`).
+
+**Google Cloud TTS** -- Set `TTS_PROVIDER=google` and configure:
+```bash
+GOOGLE_TTS_CREDENTIALS_FILE=/path/to/google-credentials.json
+GOOGLE_TTS_VOICE=en-US-Standard-C
+GOOGLE_TTS_SPEAKING_RATE=1.0
+```
+
+**Piper TTS** (local, no API key needed) -- Set `TTS_PROVIDER=piper`. See [Piper Setup](#piper-local-tts) below.
+
+### STT Provider Options
+
+**OpenAI Whisper** (default) -- Uses the OpenAI Whisper API. Requires `OPENAI_API_KEY`.
+
+**Local Whisper** -- Set `STT_PROVIDER=local` and configure:
+```bash
+WHISPER_MODEL_PATH=/models/ggml-base.en.bin
+WHISPER_BINARY=whisper-cpp  # path to whisper-cpp binary
+```
+
+## Installation Methods
+
+### 1. Bare Metal (install script)
+
+The install script handles everything on Debian/Ubuntu:
+
+```bash
+./scripts/install.sh
+```
+
+What it does:
+- Installs Node.js 22 from NodeSource (if not present or outdated)
+- Installs system packages (`git`, `curl`, `jq`, `python3`, `ripgrep`, etc.)
+- Enables pnpm via corepack
+- Creates `.env` from `.env.example` (if `.env` doesn't exist)
+- Runs `pnpm install` and `pnpm build`
+- Creates a systemd service (`voice-claude.service`) that auto-starts on boot
+- Installs the `voice-claude` CLI to `/usr/local/bin/`
+- Starts the service
+
+To update after a `git pull` (or let the CLI do it for you):
+```bash
+voice-claude update
+```
+
+### 2. Docker (Development)
+
+```bash
+cp .env.example .env
+# Edit .env with your API keys
+docker compose up
+```
+
+This mounts the source tree into the containers for hot-reloading.
+
+### 3. Docker (Production -- Build Locally)
+
+```bash
+cp .env.example .env
+# Edit .env with your API keys
+docker compose -f docker-compose.prod.yml up --build -d
+```
+
+Builds multi-stage production images. Includes Traefik labels for reverse proxy routing -- set `VOICE_CLAUDE_HOST` to your domain.
+
+### 4. Docker (Production -- Pre-built Images)
+
+```bash
+cp .env.example .env
+# Edit .env with your API keys
+docker compose -f docker-compose.ghcr.yml up -d
+```
+
+Pulls pre-built images from `ghcr.io/evanstern/voice-claude`. Use `IMAGE_TAG` to pin a version.
+
+## Piper Local TTS
+
+Piper is a local TTS engine that doesn't require any API keys. You can enable it with either the install script or Docker.
+
+**Bare metal:**
+```bash
+./scripts/install.sh --with-piper
+```
+Or set `INSTALL_PIPER=true` before running the script. This creates a Python virtualenv, installs `piper-tts`, and downloads the default voice model (`en_US-lessac-medium`).
+
+**Docker:**
+```bash
+docker compose -f docker-compose.prod.yml --profile piper up --build -d
+```
+The `piper-init` sidecar container auto-downloads the model on first run.
+
+Then set in `.env`:
+```bash
+TTS_PROVIDER=piper
+```
+
+## Reverse Proxy (Traefik)
+
+The production Docker Compose files include Traefik labels. To use them:
+
+1. Set `BEHIND_PROXY=true` in `.env`
+2. Set `VOICE_CLAUDE_HOST` to your domain (default: `voice.local.infinity-node.win`)
+3. Ensure a `traefik-network` Docker network exists (or set `TRAEFIK_NETWORK` to your network name)
+
+Routes configured:
+- `/ws` and `/trpc` → server container (port 4000)
+- `/api/health` → server container
+- Everything else → web container (port 3000)
+
+## Development
+
+```bash
+pnpm dev          # Start server + web in dev mode with hot reload
+pnpm build        # Build all packages
+pnpm lint         # Biome linter
+pnpm format       # Biome formatter
+pnpm typecheck    # TypeScript type checking
+```
+
+## Project Structure
+
+```
+voice-claude/
+├── apps/
+│   ├── server/          # Hono + tRPC backend (API, WebSocket, tool execution)
+│   └── web/             # React Router 7 PWA (mic capture, audio playback)
+├── packages/
+│   ├── contracts/       # Shared Zod schemas & types
+│   ├── shared/          # Shared utilities
+│   └── ui/              # Radix + Tailwind component library
+├── scripts/
+│   ├── install.sh       # Full setup script (Node, pnpm, deps, build, systemd)
+│   ├── start.sh         # Production process manager (ExecStart for systemd)
+│   └── voice-claude     # CLI source (installed to /usr/local/bin by install.sh)
+├── docker/              # Dockerfiles and support files
+├── models/              # Local model files (Piper voices)
+└── docs/                # Additional documentation
+```

--- a/apps/server/src/voice/claude-code-provider.ts
+++ b/apps/server/src/voice/claude-code-provider.ts
@@ -59,7 +59,7 @@ export class ClaudeCodeProvider implements AIProvider {
         proc = spawn('claude', args, {
           cwd: WORK_DIR,
           stdio: ['ignore', 'pipe', 'pipe'],
-          env: { ...process.env },
+          env: { ...process.env, ANTHROPIC_API_KEY: undefined },
         })
       } catch (err) {
         reject(

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -107,17 +107,27 @@ ensure_pnpm() {
     fail 'corepack is required after installing Node.js, but was not found.'
   fi
 
-  corepack enable
-  corepack prepare "pnpm@${PNPM_VERSION}" --activate
+  "${SUDO[@]}" corepack enable
+  "${SUDO[@]}" corepack prepare "pnpm@${PNPM_VERSION}" --activate
 }
 
 ensure_env_file() {
-  if [[ -f "${PROJECT_ROOT}/.env" ]]; then
-    return
+  if [[ ! -f "${PROJECT_ROOT}/.env" ]]; then
+    log 'Creating .env from .env.example'
+    cp "${PROJECT_ROOT}/.env.example" "${PROJECT_ROOT}/.env"
   fi
 
-  log 'Creating .env from .env.example'
-  cp "${PROJECT_ROOT}/.env.example" "${PROJECT_ROOT}/.env"
+  local current_work_dir
+  current_work_dir=$(grep -E '^WORK_DIR=' "${PROJECT_ROOT}/.env" | cut -d= -f2- || true)
+
+  if [[ -z "${current_work_dir}" ]]; then
+    log "Setting WORK_DIR=${HOME} in .env"
+    if grep -qE '^#?\s*WORK_DIR=' "${PROJECT_ROOT}/.env"; then
+      sed -i "s|^#\?\s*WORK_DIR=.*|WORK_DIR=${HOME}|" "${PROJECT_ROOT}/.env"
+    else
+      printf '\nWORK_DIR=%s\n' "${HOME}" >> "${PROJECT_ROOT}/.env"
+    fi
+  fi
 }
 
 load_env() {
@@ -172,6 +182,80 @@ setup_piper() {
   download_piper_model
 }
 
+ensure_claude_code() {
+  local ai_provider
+  ai_provider=$(grep -E '^AI_PROVIDER=' "${PROJECT_ROOT}/.env" | cut -d= -f2- || true)
+
+  if [[ "${ai_provider}" != "claude-code" ]]; then
+    return
+  fi
+
+  if command -v claude >/dev/null 2>&1; then
+    log "Claude Code CLI already installed: $(claude --version 2>&1 | head -1)"
+    return
+  fi
+
+  log 'Installing Claude Code CLI (npm install -g @anthropic-ai/claude-code)'
+  "${SUDO[@]}" npm install -g @anthropic-ai/claude-code
+
+  if ! command -v claude >/dev/null 2>&1; then
+    fail 'Claude Code CLI installed but not found in PATH. Try running: sudo npm install -g @anthropic-ai/claude-code'
+  fi
+
+  log "Claude Code CLI installed: $(claude --version 2>&1 | head -1)"
+  log 'NOTE: You must authenticate the CLI before voice-claude can use it.'
+  log '      Run: claude login'
+}
+
+setup_systemd_service() {
+  local service_file="/etc/systemd/system/voice-claude.service"
+  local run_user
+  run_user=$(whoami)
+
+  log "Setting up systemd service (user=${run_user})"
+
+  "${SUDO[@]}" tee "${service_file}" >/dev/null <<EOF
+[Unit]
+Description=voice-claude — hands-free voice interface for Claude
+After=network.target
+
+[Service]
+Type=simple
+User=${run_user}
+Environment=PATH=/home/${run_user}/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+WorkingDirectory=${PROJECT_ROOT}
+ExecStart=${PROJECT_ROOT}/scripts/start.sh
+EnvironmentFile=${PROJECT_ROOT}/.env
+Restart=on-failure
+RestartSec=5
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+  "${SUDO[@]}" systemctl daemon-reload
+  "${SUDO[@]}" systemctl enable voice-claude
+  "${SUDO[@]}" systemctl restart voice-claude
+}
+
+install_cli() {
+  local cli_src="${SCRIPT_DIR}/voice-claude"
+  local cli_dest="/usr/local/bin/voice-claude"
+
+  if [[ ! -f "${cli_src}" ]]; then
+    fail "CLI script not found at ${cli_src}"
+  fi
+
+  # Bake in the project root so the CLI works from anywhere
+  "${SUDO[@]}" cp "${cli_src}" "${cli_dest}"
+  "${SUDO[@]}" sed -i "s|__PROJECT_ROOT__|${PROJECT_ROOT}|g" "${cli_dest}"
+  "${SUDO[@]}" chmod +x "${cli_dest}"
+
+  log "Installed CLI to ${cli_dest}"
+}
+
 main() {
   cd "${PROJECT_ROOT}"
 
@@ -193,7 +277,13 @@ main() {
     log 'Skipping Piper setup'
   fi
 
+  ensure_claude_code
+  setup_systemd_service
+  install_cli
+
   log 'Install complete'
+  log 'The voice-claude service is now running.'
+  log 'Use "voice-claude status" to check, "voice-claude logs -f" to follow logs.'
 }
 
 main "$@"

--- a/scripts/voice-claude
+++ b/scripts/voice-claude
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# voice-claude CLI — lifecycle management for the voice-claude service.
+# Installed to /usr/local/bin/voice-claude by install.sh.
+
+SERVICE_NAME=voice-claude
+SERVICE_FILE="/etc/systemd/system/${SERVICE_NAME}.service"
+
+# PROJECT_ROOT is baked in by install.sh (replaced at install time).
+# Fallback: derive from script location if running from the repo directly.
+PROJECT_ROOT="__PROJECT_ROOT__"
+if [[ "${PROJECT_ROOT}" == "__PROJECT_ROOT__" ]]; then
+  SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+  PROJECT_ROOT=$(cd -- "${SCRIPT_DIR}/.." && pwd)
+fi
+
+ENV_FILE="${PROJECT_ROOT}/.env"
+
+if [[ ${EUID} -eq 0 ]]; then
+  SUDO=()
+elif command -v sudo >/dev/null 2>&1; then
+  SUDO=(sudo)
+else
+  printf 'This command needs root privileges. Run as root or install sudo.\n' >&2
+  exit 1
+fi
+
+log() { printf '[voice-claude] %s\n' "$*"; }
+fail() { printf '[voice-claude] ERROR: %s\n' "$*" >&2; exit 1; }
+
+require_service() {
+  if [[ ! -f "${SERVICE_FILE}" ]]; then
+    fail "Service not installed. Run ./scripts/install.sh first."
+  fi
+}
+
+cmd_start() {
+  require_service
+  log "Starting ${SERVICE_NAME}"
+  "${SUDO[@]}" systemctl start "${SERVICE_NAME}"
+  "${SUDO[@]}" systemctl status "${SERVICE_NAME}" --no-pager
+}
+
+cmd_stop() {
+  require_service
+  log "Stopping ${SERVICE_NAME}"
+  "${SUDO[@]}" systemctl stop "${SERVICE_NAME}"
+  log "Stopped"
+}
+
+cmd_restart() {
+  require_service
+  log "Restarting ${SERVICE_NAME}"
+  "${SUDO[@]}" systemctl restart "${SERVICE_NAME}"
+  "${SUDO[@]}" systemctl status "${SERVICE_NAME}" --no-pager
+}
+
+cmd_status() {
+  require_service
+  "${SUDO[@]}" systemctl status "${SERVICE_NAME}" --no-pager || true
+}
+
+cmd_logs() {
+  require_service
+  local follow=false
+  local lines=50
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      -f|--follow) follow=true ;;
+      -n|--lines) shift; lines="$1" ;;
+      *) ;;
+    esac
+    shift
+  done
+
+  if [[ ${follow} == true ]]; then
+    "${SUDO[@]}" journalctl -u "${SERVICE_NAME}" -f -n "${lines}"
+  else
+    "${SUDO[@]}" journalctl -u "${SERVICE_NAME}" -n "${lines}" --no-pager
+  fi
+}
+
+cmd_update() {
+  require_service
+  cd "${PROJECT_ROOT}"
+
+  log "Pulling latest changes"
+  git pull --ff-only || fail "git pull failed. Resolve manually."
+
+  if [[ -f "${ENV_FILE}" ]]; then
+    set -a; source "${ENV_FILE}"; set +a
+  fi
+
+  log "Installing dependencies"
+  pnpm install
+
+  log "Building"
+  pnpm build
+
+  log "Restarting service"
+  "${SUDO[@]}" systemctl restart "${SERVICE_NAME}"
+  "${SUDO[@]}" systemctl status "${SERVICE_NAME}" --no-pager
+
+  log "Update complete"
+}
+
+cmd_uninstall() {
+  log "Stopping and disabling ${SERVICE_NAME} service"
+  "${SUDO[@]}" systemctl stop "${SERVICE_NAME}" 2>/dev/null || true
+  "${SUDO[@]}" systemctl disable "${SERVICE_NAME}" 2>/dev/null || true
+
+  if [[ -f "${SERVICE_FILE}" ]]; then
+    "${SUDO[@]}" rm -f "${SERVICE_FILE}"
+    "${SUDO[@]}" systemctl daemon-reload
+    log "Removed ${SERVICE_FILE}"
+  fi
+
+  if [[ -L /usr/local/bin/voice-claude ]]; then
+    "${SUDO[@]}" rm -f /usr/local/bin/voice-claude
+    log "Removed /usr/local/bin/voice-claude"
+  fi
+
+  log "Uninstalled. Project files in ${PROJECT_ROOT} were not removed."
+}
+
+usage() {
+  cat <<EOF
+Usage: voice-claude <command> [options]
+
+Commands:
+  start       Start the voice-claude service
+  stop        Stop the voice-claude service
+  restart     Restart the voice-claude service
+  status      Show service status
+  logs        Show service logs (use -f to follow, -n <lines> for count)
+  update      Pull latest code, rebuild, and restart
+  uninstall   Remove the systemd service and CLI symlink
+
+EOF
+}
+
+case "${1:-}" in
+  start)     shift; cmd_start "$@" ;;
+  stop)      shift; cmd_stop "$@" ;;
+  restart)   shift; cmd_restart "$@" ;;
+  status)    shift; cmd_status "$@" ;;
+  logs)      shift; cmd_logs "$@" ;;
+  update)    shift; cmd_update "$@" ;;
+  uninstall) shift; cmd_uninstall "$@" ;;
+  -h|--help|help|"") usage ;;
+  *) printf 'Unknown command: %s\n\n' "$1" >&2; usage; exit 1 ;;
+esac


### PR DESCRIPTION
## Summary

- **`scripts/voice-claude` CLI** — new command for managing the service after install: `start`, `stop`, `restart`, `status`, `logs [-f]`, `update` (git pull + rebuild + restart), `uninstall`
- **`scripts/install.sh`** — now writes a systemd unit, installs the CLI to `/usr/local/bin`, enables + starts the service; auto-sets `WORK_DIR=$HOME` in generated `.env`; auto-installs `@anthropic-ai/claude-code` when `AI_PROVIDER=claude-code`
- **`apps/server/src/voice/claude-code-provider.ts`** — strips `ANTHROPIC_API_KEY` from the env passed to the `claude` CLI, preventing a placeholder/wrong key from overriding stored CLI auth and causing "Invalid API key" errors
- **`.env.example`** — clearer `WORK_DIR` comment for bare-metal vs Docker
- **`README.md`** — new file covering install, configuration, all env vars, deployment methods, Piper TTS, reverse proxy, and the `voice-claude` CLI