### PR TITLE
fix: voice-claude update command

### DIFF
--- a/scripts/voice-claude
+++ b/scripts/voice-claude
@@ -7,13 +7,7 @@ set -euo pipefail
 SERVICE_NAME=voice-claude
 SERVICE_FILE="/etc/systemd/system/${SERVICE_NAME}.service"
 
-# PROJECT_ROOT is baked in by install.sh (replaced at install time).
-# Fallback: derive from script location if running from the repo directly.
 PROJECT_ROOT="__PROJECT_ROOT__"
-if [[ "${PROJECT_ROOT}" == "__PROJECT_ROOT__" ]]; then
-  SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
-  PROJECT_ROOT=$(cd -- "${SCRIPT_DIR}/.." && pwd)
-fi
 
 ENV_FILE="${PROJECT_ROOT}/.env"
 
@@ -86,17 +80,19 @@ cmd_update() {
   cd "${PROJECT_ROOT}"
 
   log "Pulling latest changes"
-  git pull --ff-only || fail "git pull failed. Resolve manually."
+  local git=(env -u GIT_DIR -u GIT_WORK_TREE -u GIT_INDEX_FILE git -C "${PROJECT_ROOT}")
+  "${git[@]}" fetch origin main || fail "git fetch failed. Check network and try again."
+  "${git[@]}" reset --hard origin/main || fail "git reset failed. Resolve manually."
 
   if [[ -f "${ENV_FILE}" ]]; then
     set -a; source "${ENV_FILE}"; set +a
   fi
 
   log "Installing dependencies"
-  pnpm install
+  (cd "${PROJECT_ROOT}" && pnpm install)
 
   log "Building"
-  pnpm build
+  (cd "${PROJECT_ROOT}" && pnpm build)
 
   log "Restarting service"
   "${SUDO[@]}" systemctl restart "${SERVICE_NAME}"


### PR DESCRIPTION
## Summary

- Remove the `PROJECT_ROOT` fallback that was silently overriding the baked-in path when the script ran from `/usr/local/bin` (fallback derived parent as `/usr/local`, which is not a git repo)
- Strip `GIT_DIR`, `GIT_WORK_TREE`, `GIT_INDEX_FILE` from the environment before git commands to prevent interference from parent shell environments (e.g. opencode/coda tooling)
- Replace `git merge --ff-only` with `git reset --hard origin/main` for clean production updates that always converge to main regardless of local branch state
- Run `pnpm install` and `pnpm build` in a subshell `cd` to `PROJECT_ROOT` to ensure correct working directory