### PR TITLE
feat: add opencode provider and generalize away from Claude-only assumption

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,8 +20,9 @@ OPENAI_API_KEY=sk-...
 # "opencode" routes through a running `opencode serve` headless HTTP instance
 # AI_PROVIDER=anthropic
 
-# OpenCode headless server URL (required when AI_PROVIDER=opencode)
-# Defaults to a local `opencode serve` instance
+# OpenCode headless server URL (used when AI_PROVIDER=opencode)
+# Optional when using the default local `opencode serve` instance at http://127.0.0.1:4096
+# Set this only when your OpenCode server is running on a different host or port
 # OPENCODE_URL=http://127.0.0.1:4096
 
 # Model routing (anthropic provider): auto | sonnet | haiku (default: auto)

--- a/.env.example
+++ b/.env.example
@@ -14,10 +14,15 @@ ANTHROPIC_API_KEY=sk-ant-...
 # OpenAI API key for Whisper STT
 OPENAI_API_KEY=sk-...
 
-# AI provider: anthropic | claude-code (default: anthropic)
+# AI provider: anthropic | claude-code | opencode (default: anthropic)
 # "anthropic" uses the Anthropic API directly with run_shell and read_file tools
 # "claude-code" routes through the Claude Code CLI (requires `claude` installed and authenticated)
+# "opencode" routes through a running `opencode serve` headless HTTP instance
 # AI_PROVIDER=anthropic
+
+# OpenCode headless server URL (required when AI_PROVIDER=opencode)
+# Defaults to a local `opencode serve` instance
+# OPENCODE_URL=http://127.0.0.1:4096
 
 # Model routing (anthropic provider): auto | sonnet | haiku (default: auto)
 # auto = Haiku for simple queries, Sonnet for tool-heavy ones
@@ -54,8 +59,8 @@ OPENAI_API_KEY=sk-...
 # PIPER_MODELS_DIR=./models/piper             # host path to directory containing .onnx model files
 # PIPER_VOICE=                                # speaker name for multi-speaker models
 
-# Working directory for Claude tool execution
-# Bare metal: the directory Claude's tools (shell, file read/write) will operate in.
+# Working directory for AI tool execution
+# Bare metal: the directory AI tools (shell, file read/write) will operate in.
 # Defaults to $HOME if not set (install.sh sets this automatically).
 # Docker: this is the host directory mounted into the container at /workspace.
 # WORK_DIR=/home/youruser

--- a/apps/server/src/storage/costs.ts
+++ b/apps/server/src/storage/costs.ts
@@ -10,13 +10,13 @@ const HISTORY_FILE = join(DATA_DIR, 'history.jsonl')
 export interface CostRecord {
   timestamp: string
   sessionId: string
-  costs: { stt: number; claude: number; tts: number }
+  costs: { stt: number; llm: number; tts: number }
   usage: {
     sttDurationSec: number
-    claudeInputTokens: number
-    claudeOutputTokens: number
-    claudeCacheReadTokens: number
-    claudeCacheWriteTokens: number
+    llmInputTokens: number
+    llmOutputTokens: number
+    llmCacheReadTokens: number
+    llmCacheWriteTokens: number
     ttsChars: number
   }
   providers: Array<{ provider: string; model: string; cost: number }>
@@ -26,13 +26,13 @@ export interface AggregatedCosts {
   totalInteractions: number
   totalCost: number
   avgCostPerInteraction: number
-  costBreakdown: { stt: number; claude: number; tts: number }
+  costBreakdown: { stt: number; llm: number; tts: number }
   usage: {
     sttDurationSec: number
-    claudeInputTokens: number
-    claudeOutputTokens: number
-    claudeCacheReadTokens: number
-    claudeCacheWriteTokens: number
+    llmInputTokens: number
+    llmOutputTokens: number
+    llmCacheReadTokens: number
+    llmCacheWriteTokens: number
     ttsChars: number
   }
   byProviderModel: Array<{
@@ -83,13 +83,13 @@ export async function queryCosts(
     return t >= fromTime && t <= toTime
   })
 
-  const costBreakdown = { stt: 0, claude: 0, tts: 0 }
+  const costBreakdown = { stt: 0, llm: 0, tts: 0 }
   const usage = {
     sttDurationSec: 0,
-    claudeInputTokens: 0,
-    claudeOutputTokens: 0,
-    claudeCacheReadTokens: 0,
-    claudeCacheWriteTokens: 0,
+    llmInputTokens: 0,
+    llmOutputTokens: 0,
+    llmCacheReadTokens: 0,
+    llmCacheWriteTokens: 0,
     ttsChars: 0,
   }
   const providerMap = new Map<
@@ -99,14 +99,14 @@ export async function queryCosts(
 
   for (const r of filtered) {
     costBreakdown.stt += r.costs.stt
-    costBreakdown.claude += r.costs.claude
+    costBreakdown.llm += r.costs.llm
     costBreakdown.tts += r.costs.tts
 
     usage.sttDurationSec += r.usage.sttDurationSec
-    usage.claudeInputTokens += r.usage.claudeInputTokens
-    usage.claudeOutputTokens += r.usage.claudeOutputTokens
-    usage.claudeCacheReadTokens += r.usage.claudeCacheReadTokens
-    usage.claudeCacheWriteTokens += r.usage.claudeCacheWriteTokens
+    usage.llmInputTokens += r.usage.llmInputTokens
+    usage.llmOutputTokens += r.usage.llmOutputTokens
+    usage.llmCacheReadTokens += r.usage.llmCacheReadTokens
+    usage.llmCacheWriteTokens += r.usage.llmCacheWriteTokens
     usage.ttsChars += r.usage.ttsChars
 
     for (const p of r.providers) {
@@ -121,7 +121,7 @@ export async function queryCosts(
     }
   }
 
-  const totalCost = costBreakdown.stt + costBreakdown.claude + costBreakdown.tts
+  const totalCost = costBreakdown.stt + costBreakdown.llm + costBreakdown.tts
   const totalInteractions = filtered.length
 
   return {

--- a/apps/server/src/storage/costs.ts
+++ b/apps/server/src/storage/costs.ts
@@ -58,6 +58,33 @@ export async function appendCostRecord(record: CostRecord): Promise<void> {
   await appendFile(HISTORY_FILE, `${JSON.stringify(record)}\n`)
 }
 
+function normalizeLegacyRecord(raw: Record<string, unknown>): CostRecord {
+  const costs = (raw.costs ?? {}) as Record<string, number>
+  const usage = (raw.usage ?? {}) as Record<string, number>
+  return {
+    timestamp: (raw.timestamp as string) ?? '',
+    sessionId: (raw.sessionId as string) ?? '',
+    costs: {
+      stt: costs.stt ?? 0,
+      llm: costs.llm ?? costs.claude ?? 0,
+      tts: costs.tts ?? 0,
+    },
+    usage: {
+      sttDurationSec: usage.sttDurationSec ?? 0,
+      llmInputTokens:
+        usage.llmInputTokens ?? usage.claudeInputTokens ?? 0,
+      llmOutputTokens:
+        usage.llmOutputTokens ?? usage.claudeOutputTokens ?? 0,
+      llmCacheReadTokens:
+        usage.llmCacheReadTokens ?? usage.claudeCacheReadTokens ?? 0,
+      llmCacheWriteTokens:
+        usage.llmCacheWriteTokens ?? usage.claudeCacheWriteTokens ?? 0,
+      ttsChars: usage.ttsChars ?? 0,
+    },
+    providers: (raw.providers as CostRecord['providers']) ?? [],
+  }
+}
+
 async function readAllRecords(): Promise<CostRecord[]> {
   await ensureDir()
   let content: string
@@ -67,7 +94,9 @@ async function readAllRecords(): Promise<CostRecord[]> {
     return []
   }
   if (!content) return []
-  return content.split('\n').map((line) => JSON.parse(line) as CostRecord)
+  return content
+    .split('\n')
+    .map((line) => normalizeLegacyRecord(JSON.parse(line)))
 }
 
 export async function queryCosts(

--- a/apps/server/src/storage/costs.ts
+++ b/apps/server/src/storage/costs.ts
@@ -71,10 +71,8 @@ function normalizeLegacyRecord(raw: Record<string, unknown>): CostRecord {
     },
     usage: {
       sttDurationSec: usage.sttDurationSec ?? 0,
-      llmInputTokens:
-        usage.llmInputTokens ?? usage.claudeInputTokens ?? 0,
-      llmOutputTokens:
-        usage.llmOutputTokens ?? usage.claudeOutputTokens ?? 0,
+      llmInputTokens: usage.llmInputTokens ?? usage.claudeInputTokens ?? 0,
+      llmOutputTokens: usage.llmOutputTokens ?? usage.claudeOutputTokens ?? 0,
       llmCacheReadTokens:
         usage.llmCacheReadTokens ?? usage.claudeCacheReadTokens ?? 0,
       llmCacheWriteTokens:

--- a/apps/server/src/voice/__tests__/voice-context.test.ts
+++ b/apps/server/src/voice/__tests__/voice-context.test.ts
@@ -8,9 +8,9 @@ describe('buildVoiceContext', () => {
       '\nAvailable CLI tools: git (version control), node (Node.js runtime).',
   }
 
-  it('includes Voice Claude identity', () => {
+  it('includes Voice Assistant identity', () => {
     const ctx = buildVoiceContext(defaultOptions)
-    expect(ctx.systemPrompt).toContain('Voice Claude')
+    expect(ctx.systemPrompt).toContain('Voice Assistant')
     expect(ctx.systemPrompt).toContain('hands-free voice coding assistant')
   })
 
@@ -41,6 +41,14 @@ describe('buildVoiceContext', () => {
     expect(ctx.systemPrompt).toContain('Claude Code')
   })
 
+  it('mentions OpenCode when provider hint is opencode', () => {
+    const ctx = buildVoiceContext({
+      ...defaultOptions,
+      providerHint: 'opencode',
+    })
+    expect(ctx.systemPrompt).toContain('OpenCode')
+  })
+
   it('does not mention Claude Code when provider hint is anthropic', () => {
     const ctx = buildVoiceContext({
       ...defaultOptions,
@@ -51,7 +59,7 @@ describe('buildVoiceContext', () => {
 
   it('handles empty environment string', () => {
     const ctx = buildVoiceContext({ ...defaultOptions, environment: '' })
-    expect(ctx.systemPrompt).toContain('Voice Claude')
+    expect(ctx.systemPrompt).toContain('Voice Assistant')
     expect(ctx.systemPrompt).not.toContain('Available CLI tools')
   })
 })

--- a/apps/server/src/voice/__tests__/voice-middleware.test.ts
+++ b/apps/server/src/voice/__tests__/voice-middleware.test.ts
@@ -18,7 +18,7 @@ describe('processVoiceInput', () => {
 
   it('returns voice context with system prompt', async () => {
     const result = await processVoiceInput(defaultInput)
-    expect(result.voiceContext.systemPrompt).toContain('Voice Claude')
+    expect(result.voiceContext.systemPrompt).toContain('Voice Assistant')
   })
 
   it('processes keywords and returns intents', async () => {
@@ -63,6 +63,14 @@ describe('processVoiceInput', () => {
       provider: 'anthropic',
     })
     expect(result.voiceContext.systemPrompt).not.toContain('Claude Code')
+  })
+
+  it('mentions OpenCode for opencode provider', async () => {
+    const result = await processVoiceInput({
+      ...defaultInput,
+      provider: 'opencode',
+    })
+    expect(result.voiceContext.systemPrompt).toContain('OpenCode')
   })
 
   it('separates displayText (clean) from chatText (with decorations)', async () => {

--- a/apps/server/src/voice/ai-provider.ts
+++ b/apps/server/src/voice/ai-provider.ts
@@ -1,6 +1,7 @@
 import { logger } from '../logger.js'
 import { AnthropicProvider } from './anthropic-provider.js'
 import { ClaudeCodeProvider } from './claude-code-provider.js'
+import { OpenCodeProvider } from './opencode-provider.js'
 import type { VoiceContext } from './voice-context.js'
 
 const log = logger.child({ module: 'ai' })
@@ -41,6 +42,7 @@ export interface ChatResponse {
 const providers: Record<string, () => AIProvider> = {
   anthropic: () => new AnthropicProvider(),
   'claude-code': () => new ClaudeCodeProvider(),
+  opencode: () => new OpenCodeProvider(),
 }
 
 let cached: AIProvider | null = null

--- a/apps/server/src/voice/ai-provider.ts
+++ b/apps/server/src/voice/ai-provider.ts
@@ -35,6 +35,10 @@ export interface ChatResponse {
     cache_read_input_tokens: number
   }
   model: string
+  /** Upstream provider identifier (e.g. "anthropic", "openai") when available. */
+  providerID?: string
+  /** Cost reported by the upstream provider/harness. When set and > 0, used instead of token-based estimation. */
+  reportedCost?: number
 }
 
 // --- Provider factory ---

--- a/apps/server/src/voice/claude.ts
+++ b/apps/server/src/voice/claude.ts
@@ -1,5 +1,4 @@
 // Thin wrapper that delegates to the configured AI provider.
-// Preserves the original export signatures so audio.ts can migrate incrementally.
 
 import {
   type ChatParams,
@@ -7,9 +6,6 @@ import {
   getAIProvider,
 } from './ai-provider.js'
 import type { VoiceContext } from './voice-context.js'
-
-export type { ChatResponse as ClaudeResponse }
-export type ClaudeUsageResult = ChatResponse['usage']
 
 export async function chat(
   sessionId: string,

--- a/apps/server/src/voice/cost-tracker.ts
+++ b/apps/server/src/voice/cost-tracker.ts
@@ -1,5 +1,3 @@
-// Per-interaction cost tracking for STT, Claude, and TTS API calls.
-
 import { logger } from '../logger.js'
 import { appendCostRecord } from '../storage/costs.js'
 
@@ -9,17 +7,16 @@ const log = logger.child({ module: 'cost' })
 const RATES = {
   // Whisper: $0.006 per minute of audio
   whisperPerMinute: 0.006,
-  // Claude Sonnet: $3 per 1M input tokens, $15 per 1M output tokens
-  claudeInputPer1M: 3,
-  claudeOutputPer1M: 15,
+  llmInputPer1M: 3,
+  llmOutputPer1M: 15,
   // Cache tokens: input tokens read from cache are 90% cheaper, write is 25% more
-  claudeCacheReadPer1M: 0.3,
-  claudeCacheWritePer1M: 3.75,
+  llmCacheReadPer1M: 0.3,
+  llmCacheWritePer1M: 3.75,
   // OpenAI TTS (tts-1): $15 per 1M characters
   ttsCharsPer1M: 15,
 } as const
 
-export interface ClaudeUsage {
+export interface LLMUsage {
   input_tokens: number
   output_tokens: number
   cache_creation_input_tokens?: number
@@ -28,7 +25,7 @@ export interface ClaudeUsage {
 
 interface ServiceCosts {
   stt: number
-  claude: number
+  llm: number
   tts: number
 }
 
@@ -43,10 +40,10 @@ interface SessionStats {
   interactions: number
   costs: ServiceCosts
   sttDurationSec: number
-  claudeInputTokens: number
-  claudeOutputTokens: number
-  claudeCacheReadTokens: number
-  claudeCacheWriteTokens: number
+  llmInputTokens: number
+  llmOutputTokens: number
+  llmCacheReadTokens: number
+  llmCacheWriteTokens: number
   ttsChars: number
 }
 
@@ -54,10 +51,10 @@ interface GlobalStats {
   totalInteractions: number
   totalCosts: ServiceCosts
   totalSttDurationSec: number
-  totalClaudeInputTokens: number
-  totalClaudeOutputTokens: number
-  totalClaudeCacheReadTokens: number
-  totalClaudeCacheWriteTokens: number
+  totalLlmInputTokens: number
+  totalLlmOutputTokens: number
+  totalLlmCacheReadTokens: number
+  totalLlmCacheWriteTokens: number
   totalTtsChars: number
   sessions: number
   startedAt: string
@@ -67,12 +64,12 @@ interface GlobalStats {
 const sessionData = new Map<string, SessionStats>()
 const globalStats: GlobalStats = {
   totalInteractions: 0,
-  totalCosts: { stt: 0, claude: 0, tts: 0 },
+  totalCosts: { stt: 0, llm: 0, tts: 0 },
   totalSttDurationSec: 0,
-  totalClaudeInputTokens: 0,
-  totalClaudeOutputTokens: 0,
-  totalClaudeCacheReadTokens: 0,
-  totalClaudeCacheWriteTokens: 0,
+  totalLlmInputTokens: 0,
+  totalLlmOutputTokens: 0,
+  totalLlmCacheReadTokens: 0,
+  totalLlmCacheWriteTokens: 0,
   totalTtsChars: 0,
   sessions: 0,
   startedAt: new Date().toISOString(),
@@ -99,7 +96,7 @@ function trackProviderModel(
 // Pending costs for the current interaction (accumulated across calls, logged together)
 const pendingCosts = new Map<
   string,
-  { stt: number; claude: number; tts: number }
+  { stt: number; llm: number; tts: number }
 >()
 
 // Pending usage metrics for the current interaction (for persistence)
@@ -107,10 +104,10 @@ const pendingUsage = new Map<
   string,
   {
     sttDurationSec: number
-    claudeInputTokens: number
-    claudeOutputTokens: number
-    claudeCacheReadTokens: number
-    claudeCacheWriteTokens: number
+    llmInputTokens: number
+    llmOutputTokens: number
+    llmCacheReadTokens: number
+    llmCacheWriteTokens: number
     ttsChars: number
   }
 >()
@@ -126,12 +123,12 @@ function ensureSession(sessionId: string): SessionStats {
     globalStats.sessions++
     sessionData.set(sessionId, {
       interactions: 0,
-      costs: { stt: 0, claude: 0, tts: 0 },
+      costs: { stt: 0, llm: 0, tts: 0 },
       sttDurationSec: 0,
-      claudeInputTokens: 0,
-      claudeOutputTokens: 0,
-      claudeCacheReadTokens: 0,
-      claudeCacheWriteTokens: 0,
+      llmInputTokens: 0,
+      llmOutputTokens: 0,
+      llmCacheReadTokens: 0,
+      llmCacheWriteTokens: 0,
       ttsChars: 0,
     })
   }
@@ -142,11 +139,11 @@ function ensureSession(sessionId: string): SessionStats {
 
 function ensurePending(sessionId: string): {
   stt: number
-  claude: number
+  llm: number
   tts: number
 } {
   if (!pendingCosts.has(sessionId)) {
-    pendingCosts.set(sessionId, { stt: 0, claude: 0, tts: 0 })
+    pendingCosts.set(sessionId, { stt: 0, llm: 0, tts: 0 })
   }
   const pending = pendingCosts.get(sessionId)
   if (!pending)
@@ -159,10 +156,10 @@ function ensurePendingUsage(sessionId: string) {
   if (!usage) {
     usage = {
       sttDurationSec: 0,
-      claudeInputTokens: 0,
-      claudeOutputTokens: 0,
-      claudeCacheReadTokens: 0,
-      claudeCacheWriteTokens: 0,
+      llmInputTokens: 0,
+      llmOutputTokens: 0,
+      llmCacheReadTokens: 0,
+      llmCacheWriteTokens: 0,
       ttsChars: 0,
     }
     pendingUsage.set(sessionId, usage)
@@ -206,43 +203,42 @@ export function recordSTT(
   return cost
 }
 
-export function recordClaude(
+export function recordLLM(
   sessionId: string,
-  usage: ClaudeUsage,
+  usage: LLMUsage,
   model = 'claude-sonnet-4-6',
+  provider = 'anthropic',
 ): number {
-  const inputCost = (usage.input_tokens / 1_000_000) * RATES.claudeInputPer1M
-  const outputCost = (usage.output_tokens / 1_000_000) * RATES.claudeOutputPer1M
+  const inputCost = (usage.input_tokens / 1_000_000) * RATES.llmInputPer1M
+  const outputCost = (usage.output_tokens / 1_000_000) * RATES.llmOutputPer1M
   const cacheReadCost =
-    ((usage.cache_read_input_tokens ?? 0) / 1_000_000) *
-    RATES.claudeCacheReadPer1M
+    ((usage.cache_read_input_tokens ?? 0) / 1_000_000) * RATES.llmCacheReadPer1M
   const cacheWriteCost =
     ((usage.cache_creation_input_tokens ?? 0) / 1_000_000) *
-    RATES.claudeCacheWritePer1M
+    RATES.llmCacheWritePer1M
   const cost = inputCost + outputCost + cacheReadCost + cacheWriteCost
 
   const session = ensureSession(sessionId)
-  session.costs.claude += cost
-  session.claudeInputTokens += usage.input_tokens
-  session.claudeOutputTokens += usage.output_tokens
-  session.claudeCacheReadTokens += usage.cache_read_input_tokens ?? 0
-  session.claudeCacheWriteTokens += usage.cache_creation_input_tokens ?? 0
-  globalStats.totalCosts.claude += cost
-  globalStats.totalClaudeInputTokens += usage.input_tokens
-  globalStats.totalClaudeOutputTokens += usage.output_tokens
-  globalStats.totalClaudeCacheReadTokens += usage.cache_read_input_tokens ?? 0
-  globalStats.totalClaudeCacheWriteTokens +=
-    usage.cache_creation_input_tokens ?? 0
-  trackProviderModel('anthropic', model, cost)
+  session.costs.llm += cost
+  session.llmInputTokens += usage.input_tokens
+  session.llmOutputTokens += usage.output_tokens
+  session.llmCacheReadTokens += usage.cache_read_input_tokens ?? 0
+  session.llmCacheWriteTokens += usage.cache_creation_input_tokens ?? 0
+  globalStats.totalCosts.llm += cost
+  globalStats.totalLlmInputTokens += usage.input_tokens
+  globalStats.totalLlmOutputTokens += usage.output_tokens
+  globalStats.totalLlmCacheReadTokens += usage.cache_read_input_tokens ?? 0
+  globalStats.totalLlmCacheWriteTokens += usage.cache_creation_input_tokens ?? 0
+  trackProviderModel(provider, model, cost)
 
   const pending = ensurePending(sessionId)
-  pending.claude += cost
+  pending.llm += cost
   const pu = ensurePendingUsage(sessionId)
-  pu.claudeInputTokens += usage.input_tokens
-  pu.claudeOutputTokens += usage.output_tokens
-  pu.claudeCacheReadTokens += usage.cache_read_input_tokens ?? 0
-  pu.claudeCacheWriteTokens += usage.cache_creation_input_tokens ?? 0
-  addPendingProvider(sessionId, 'anthropic', model, cost)
+  pu.llmInputTokens += usage.input_tokens
+  pu.llmOutputTokens += usage.output_tokens
+  pu.llmCacheReadTokens += usage.cache_read_input_tokens ?? 0
+  pu.llmCacheWriteTokens += usage.cache_creation_input_tokens ?? 0
+  addPendingProvider(sessionId, provider, model, cost)
   return cost
 }
 
@@ -268,28 +264,24 @@ export function recordTTS(
   return cost
 }
 
-/**
- * Call after each full interaction (STT + Claude + TTS) to log the cost
- * summary and increment the interaction counter.
- */
 export function finalizeInteraction(sessionId: string): void {
   const session = ensureSession(sessionId)
   session.interactions++
   globalStats.totalInteractions++
 
-  const pending = pendingCosts.get(sessionId) ?? { stt: 0, claude: 0, tts: 0 }
-  const total = pending.stt + pending.claude + pending.tts
+  const pending = pendingCosts.get(sessionId) ?? { stt: 0, llm: 0, tts: 0 }
+  const total = pending.stt + pending.llm + pending.tts
 
   log.info(
     {
       interaction: globalStats.totalInteractions,
       stt: pending.stt.toFixed(4),
-      claude: pending.claude.toFixed(4),
+      llm: pending.llm.toFixed(4),
       tts: pending.tts.toFixed(4),
       total: total.toFixed(4),
       cumulative: (
         globalStats.totalCosts.stt +
-        globalStats.totalCosts.claude +
+        globalStats.totalCosts.llm +
         globalStats.totalCosts.tts
       ).toFixed(4),
     },
@@ -299,10 +291,10 @@ export function finalizeInteraction(sessionId: string): void {
   // Persist to disk for historical queries
   const usage = pendingUsage.get(sessionId) ?? {
     sttDurationSec: 0,
-    claudeInputTokens: 0,
-    claudeOutputTokens: 0,
-    claudeCacheReadTokens: 0,
-    claudeCacheWriteTokens: 0,
+    llmInputTokens: 0,
+    llmOutputTokens: 0,
+    llmCacheReadTokens: 0,
+    llmCacheWriteTokens: 0,
     ttsChars: 0,
   }
   const providers = pendingProviders.get(sessionId) ?? []
@@ -333,7 +325,7 @@ export function cleanupSession(sessionId: string): void {
 export function getStats() {
   const totalCost =
     globalStats.totalCosts.stt +
-    globalStats.totalCosts.claude +
+    globalStats.totalCosts.llm +
     globalStats.totalCosts.tts
 
   const avgCostPerInteraction =
@@ -344,7 +336,7 @@ export function getStats() {
   const sessionSummaries = Array.from(sessionData.entries()).map(([id, s]) => ({
     sessionId: id.slice(0, 8),
     interactions: s.interactions,
-    totalCost: s.costs.stt + s.costs.claude + s.costs.tts,
+    totalCost: s.costs.stt + s.costs.llm + s.costs.tts,
     costs: { ...s.costs },
   }))
 
@@ -359,10 +351,10 @@ export function getStats() {
     costBreakdown: { ...globalStats.totalCosts },
     usage: {
       sttDurationSec: globalStats.totalSttDurationSec,
-      claudeInputTokens: globalStats.totalClaudeInputTokens,
-      claudeOutputTokens: globalStats.totalClaudeOutputTokens,
-      claudeCacheReadTokens: globalStats.totalClaudeCacheReadTokens,
-      claudeCacheWriteTokens: globalStats.totalClaudeCacheWriteTokens,
+      llmInputTokens: globalStats.totalLlmInputTokens,
+      llmOutputTokens: globalStats.totalLlmOutputTokens,
+      llmCacheReadTokens: globalStats.totalLlmCacheReadTokens,
+      llmCacheWriteTokens: globalStats.totalLlmCacheWriteTokens,
       ttsChars: globalStats.totalTtsChars,
     },
     byProviderModel,

--- a/apps/server/src/voice/cost-tracker.ts
+++ b/apps/server/src/voice/cost-tracker.ts
@@ -3,16 +3,14 @@ import { appendCostRecord } from '../storage/costs.js'
 
 const log = logger.child({ module: 'cost' })
 
-// Pricing rates
+// Fallback pricing rates (Anthropic Claude Sonnet defaults).
+// Used only when the provider does not report cost via reportedCost.
 const RATES = {
-  // Whisper: $0.006 per minute of audio
   whisperPerMinute: 0.006,
   llmInputPer1M: 3,
   llmOutputPer1M: 15,
-  // Cache tokens: input tokens read from cache are 90% cheaper, write is 25% more
   llmCacheReadPer1M: 0.3,
   llmCacheWritePer1M: 3.75,
-  // OpenAI TTS (tts-1): $15 per 1M characters
   ttsCharsPer1M: 15,
 } as const
 

--- a/apps/server/src/voice/cost-tracker.ts
+++ b/apps/server/src/voice/cost-tracker.ts
@@ -208,15 +208,22 @@ export function recordLLM(
   usage: LLMUsage,
   model = 'claude-sonnet-4-6',
   provider = 'anthropic',
+  reportedCost?: number,
 ): number {
-  const inputCost = (usage.input_tokens / 1_000_000) * RATES.llmInputPer1M
-  const outputCost = (usage.output_tokens / 1_000_000) * RATES.llmOutputPer1M
-  const cacheReadCost =
-    ((usage.cache_read_input_tokens ?? 0) / 1_000_000) * RATES.llmCacheReadPer1M
-  const cacheWriteCost =
-    ((usage.cache_creation_input_tokens ?? 0) / 1_000_000) *
-    RATES.llmCacheWritePer1M
-  const cost = inputCost + outputCost + cacheReadCost + cacheWriteCost
+  let cost: number
+  if (reportedCost != null && reportedCost > 0) {
+    cost = reportedCost
+  } else {
+    const inputCost = (usage.input_tokens / 1_000_000) * RATES.llmInputPer1M
+    const outputCost = (usage.output_tokens / 1_000_000) * RATES.llmOutputPer1M
+    const cacheReadCost =
+      ((usage.cache_read_input_tokens ?? 0) / 1_000_000) *
+      RATES.llmCacheReadPer1M
+    const cacheWriteCost =
+      ((usage.cache_creation_input_tokens ?? 0) / 1_000_000) *
+      RATES.llmCacheWritePer1M
+    cost = inputCost + outputCost + cacheReadCost + cacheWriteCost
+  }
 
   const session = ensureSession(sessionId)
   session.costs.llm += cost

--- a/apps/server/src/voice/opencode-provider.ts
+++ b/apps/server/src/voice/opencode-provider.ts
@@ -175,10 +175,28 @@ export class OpenCodeProvider implements AIProvider {
         throw error
       }
 
+      // Rethrow application-level errors from the server as-is
+      if (
+        error instanceof Error &&
+        error.message.startsWith('OpenCode request failed')
+      ) {
+        throw error
+      }
+
+      // Surface JSON parse failures clearly
+      if (error instanceof SyntaxError) {
+        throw new Error(
+          `OpenCode server at ${this.baseUrl} returned invalid JSON for ${url}: ${error.message}`,
+          { cause: error },
+        )
+      }
+
+      // Network-level failures (ECONNREFUSED, DNS, timeout, etc.)
       const message =
         error instanceof Error ? error.message : 'Unknown network error'
       throw new Error(
         `Failed to reach OpenCode server at ${this.baseUrl}: ${message}`,
+        { cause: error instanceof Error ? error : undefined },
       )
     } finally {
       signal?.removeEventListener('abort', onAbort)

--- a/apps/server/src/voice/opencode-provider.ts
+++ b/apps/server/src/voice/opencode-provider.ts
@@ -16,6 +16,8 @@ interface OpenCodeSessionResponse {
 interface OpenCodeMessageResponse {
   info?: {
     modelID?: string
+    providerID?: string
+    cost?: number
     tokens?: {
       input?: number
       output?: number
@@ -34,6 +36,10 @@ export class OpenCodeProvider implements AIProvider {
   private readonly baseUrl = process.env.OPENCODE_URL ?? DEFAULT_OPENCODE_URL
   private sessionMap = new Map<string, string>()
   private sessionLastActive = new Map<string, number>()
+  private pendingHistory = new Map<
+    string,
+    Array<{ role: 'user' | 'assistant'; content: string }>
+  >()
   private evictionTimer: ReturnType<typeof setInterval>
 
   constructor() {
@@ -63,9 +69,20 @@ export class OpenCodeProvider implements AIProvider {
     )
     this.sessionLastActive.set(params.sessionId, Date.now())
 
-    const promptText = params.voiceContext
-      ? `${VOICE_MODE_PREFIX}${params.userText}`
-      : params.userText
+    let promptText = params.userText
+
+    const history = this.pendingHistory.get(params.sessionId)
+    if (history && history.length > 0) {
+      this.pendingHistory.delete(params.sessionId)
+      const summary = history
+        .map((m) => `${m.role === 'user' ? 'User' : 'Assistant'}: ${m.content}`)
+        .join('\n')
+      promptText = `[CONVERSATION HISTORY - the user is resuming a previous conversation]\n${summary}\n\n[CURRENT MESSAGE]\n${promptText}`
+    }
+
+    if (params.voiceContext) {
+      promptText = `${VOICE_MODE_PREFIX}${promptText}`
+    }
 
     const response = await this.request<OpenCodeMessageResponse>(
       `/session/${ocSessionId}/message`,
@@ -90,6 +107,10 @@ export class OpenCodeProvider implements AIProvider {
       params.onToolUse?.(toolCall.name, toolCall.input)
     }
 
+    if (!response.info?.tokens) {
+      log.warn('opencode response missing token usage data')
+    }
+
     return {
       text,
       toolCalls,
@@ -100,18 +121,29 @@ export class OpenCodeProvider implements AIProvider {
         cache_read_input_tokens: response.info?.tokens?.cache?.read ?? 0,
       },
       model: response.info?.modelID ?? 'opencode',
+      providerID: response.info?.providerID,
+      reportedCost: response.info?.cost,
     }
   }
 
   clearSession(sessionId: string): void {
     this.sessionMap.delete(sessionId)
     this.sessionLastActive.delete(sessionId)
+    this.pendingHistory.delete(sessionId)
   }
 
   restoreSession(
-    _sessionId: string,
-    _history: Array<{ role: 'user' | 'assistant'; content: string }>,
-  ): void {}
+    sessionId: string,
+    history: Array<{ role: 'user' | 'assistant'; content: string }>,
+  ): void {
+    if (history.length > 0) {
+      this.pendingHistory.set(sessionId, history)
+      log.info(
+        { session: sessionId.slice(0, 8), messageCount: history.length },
+        'session history queued for restoration',
+      )
+    }
+  }
 
   private async getOrCreateSessionId(
     sessionId: string,

--- a/apps/server/src/voice/opencode-provider.ts
+++ b/apps/server/src/voice/opencode-provider.ts
@@ -40,6 +40,7 @@ export class OpenCodeProvider implements AIProvider {
     string,
     Array<{ role: 'user' | 'assistant'; content: string }>
   >()
+  private pendingSessionCreation = new Map<string, Promise<string>>()
   private evictionTimer: ReturnType<typeof setInterval>
 
   constructor() {
@@ -56,6 +57,8 @@ export class OpenCodeProvider implements AIProvider {
           )
           this.sessionMap.delete(sessionId)
           this.sessionLastActive.delete(sessionId)
+          this.pendingHistory.delete(sessionId)
+          this.pendingSessionCreation.delete(sessionId)
         }
       }
     }, SESSION_EVICTION_INTERVAL_MS)
@@ -152,6 +155,22 @@ export class OpenCodeProvider implements AIProvider {
     const existing = this.sessionMap.get(sessionId)
     if (existing) return existing
 
+    const inflight = this.pendingSessionCreation.get(sessionId)
+    if (inflight) return inflight
+
+    const promise = this.createSession(sessionId, signal)
+    this.pendingSessionCreation.set(sessionId, promise)
+    try {
+      return await promise
+    } finally {
+      this.pendingSessionCreation.delete(sessionId)
+    }
+  }
+
+  private async createSession(
+    sessionId: string,
+    signal?: AbortSignal,
+  ): Promise<string> {
     const created = await this.request<OpenCodeSessionResponse>(
       '/session',
       {

--- a/apps/server/src/voice/opencode-provider.ts
+++ b/apps/server/src/voice/opencode-provider.ts
@@ -1,0 +1,236 @@
+import { logger } from '../logger.js'
+import type { AIProvider, ChatParams, ChatResponse } from './ai-provider.js'
+
+const log = logger.child({ module: 'opencode' })
+
+const SESSION_TTL_MS = 30 * 60 * 1000
+const SESSION_EVICTION_INTERVAL_MS = 5 * 60 * 1000
+const DEFAULT_OPENCODE_URL = 'http://127.0.0.1:4096'
+const VOICE_MODE_PREFIX =
+  '[VOICE MODE - respond in 2-3 spoken sentences max, no markdown, no code blocks, plain spoken language]\n\n'
+
+interface OpenCodeSessionResponse {
+  id: string
+}
+
+interface OpenCodeMessageResponse {
+  info?: {
+    modelID?: string
+    tokens?: {
+      input?: number
+      output?: number
+      cache?: {
+        write?: number
+        read?: number
+      }
+    }
+  }
+  parts?: Array<Record<string, unknown>>
+}
+
+export class OpenCodeProvider implements AIProvider {
+  readonly name = 'opencode'
+
+  private readonly baseUrl = process.env.OPENCODE_URL ?? DEFAULT_OPENCODE_URL
+  private sessionMap = new Map<string, string>()
+  private sessionLastActive = new Map<string, number>()
+  private evictionTimer: ReturnType<typeof setInterval>
+
+  constructor() {
+    this.evictionTimer = setInterval(() => {
+      const now = Date.now()
+      for (const [sessionId, lastActive] of this.sessionLastActive) {
+        if (now - lastActive > SESSION_TTL_MS) {
+          log.debug(
+            {
+              session: sessionId.slice(0, 8),
+              inactiveMin: Math.round((now - lastActive) / 1000 / 60),
+            },
+            'evicting stale session mapping',
+          )
+          this.sessionMap.delete(sessionId)
+          this.sessionLastActive.delete(sessionId)
+        }
+      }
+    }, SESSION_EVICTION_INTERVAL_MS)
+    this.evictionTimer.unref()
+  }
+
+  async chat(params: ChatParams): Promise<ChatResponse> {
+    const ocSessionId = await this.getOrCreateSessionId(
+      params.sessionId,
+      params.signal,
+    )
+    this.sessionLastActive.set(params.sessionId, Date.now())
+
+    const promptText = params.voiceContext
+      ? `${VOICE_MODE_PREFIX}${params.userText}`
+      : params.userText
+
+    const response = await this.request<OpenCodeMessageResponse>(
+      `/session/${ocSessionId}/message`,
+      {
+        method: 'POST',
+        body: JSON.stringify({
+          parts: [{ type: 'text', text: promptText }],
+        }),
+      },
+      params.signal,
+    )
+
+    const parts = Array.isArray(response.parts) ? response.parts : []
+    const text = parts
+      .filter((part) => part.type === 'text')
+      .map((part) => this.readString(part.text))
+      .filter(Boolean)
+      .join('\n')
+
+    const toolCalls = this.extractToolCalls(parts)
+    for (const toolCall of toolCalls) {
+      params.onToolUse?.(toolCall.name, toolCall.input)
+    }
+
+    return {
+      text,
+      toolCalls,
+      usage: {
+        input_tokens: response.info?.tokens?.input ?? 0,
+        output_tokens: response.info?.tokens?.output ?? 0,
+        cache_creation_input_tokens: response.info?.tokens?.cache?.write ?? 0,
+        cache_read_input_tokens: response.info?.tokens?.cache?.read ?? 0,
+      },
+      model: response.info?.modelID ?? 'opencode',
+    }
+  }
+
+  clearSession(sessionId: string): void {
+    this.sessionMap.delete(sessionId)
+    this.sessionLastActive.delete(sessionId)
+  }
+
+  restoreSession(
+    _sessionId: string,
+    _history: Array<{ role: 'user' | 'assistant'; content: string }>,
+  ): void {}
+
+  private async getOrCreateSessionId(
+    sessionId: string,
+    signal?: AbortSignal,
+  ): Promise<string> {
+    const existing = this.sessionMap.get(sessionId)
+    if (existing) return existing
+
+    const created = await this.request<OpenCodeSessionResponse>(
+      '/session',
+      {
+        method: 'POST',
+        body: JSON.stringify({}),
+      },
+      signal,
+    )
+
+    this.sessionMap.set(sessionId, created.id)
+    this.sessionLastActive.set(sessionId, Date.now())
+    return created.id
+  }
+
+  private async request<T>(
+    pathname: string,
+    init: RequestInit,
+    signal?: AbortSignal,
+  ): Promise<T> {
+    const controller = new AbortController()
+    const onAbort = () => controller.abort(signal?.reason)
+
+    if (signal) {
+      if (signal.aborted) {
+        controller.abort(signal.reason)
+      } else {
+        signal.addEventListener('abort', onAbort, { once: true })
+      }
+    }
+
+    const url = new URL(pathname, this.baseUrl).toString()
+
+    try {
+      const response = await fetch(url, {
+        ...init,
+        headers: {
+          'content-type': 'application/json',
+          ...(init.headers ?? {}),
+        },
+        signal: controller.signal,
+      })
+
+      if (!response.ok) {
+        const body = await response.text().catch(() => '')
+        throw new Error(
+          `OpenCode request failed (${response.status} ${response.statusText}) at ${url}${body ? `: ${body}` : ''}`,
+        )
+      }
+
+      return (await response.json()) as T
+    } catch (error) {
+      if (controller.signal.aborted) {
+        throw error
+      }
+
+      const message =
+        error instanceof Error ? error.message : 'Unknown network error'
+      throw new Error(
+        `Failed to reach OpenCode server at ${this.baseUrl}: ${message}`,
+      )
+    } finally {
+      signal?.removeEventListener('abort', onAbort)
+    }
+  }
+
+  private extractToolCalls(
+    parts: Array<Record<string, unknown>>,
+  ): ChatResponse['toolCalls'] {
+    return parts
+      .filter((part) => {
+        const type = this.readString(part.type)
+        return Boolean(type?.includes('tool'))
+      })
+      .map((part) => {
+        const name =
+          this.readString(part.name) ||
+          this.readString(
+            (part.tool as Record<string, unknown> | undefined)?.name,
+          ) ||
+          'tool'
+
+        const inputValue =
+          part.input ??
+          part.args ??
+          part.parameters ??
+          part.payload ??
+          part.arguments ??
+          null
+
+        const resultValue =
+          part.result ?? part.output ?? part.content ?? part.text ?? null
+
+        return {
+          name,
+          input: this.serializeValue(inputValue),
+          result: this.serializeValue(resultValue),
+        }
+      })
+  }
+
+  private readString(value: unknown): string {
+    return typeof value === 'string' ? value : ''
+  }
+
+  private serializeValue(value: unknown): string {
+    if (typeof value === 'string') return value
+    if (value == null) return ''
+    try {
+      return JSON.stringify(value)
+    } catch {
+      return String(value)
+    }
+  }
+}

--- a/apps/server/src/voice/text-filter.ts
+++ b/apps/server/src/voice/text-filter.ts
@@ -1,5 +1,5 @@
 /**
- * Filters Claude's response text before TTS synthesis.
+ * Filters AI response text before TTS synthesis.
  *
  * Strips code blocks, inline code, and raw file paths so that only
  * the conversational / spoken portion is sent to the TTS engine.

--- a/apps/server/src/voice/voice-context.ts
+++ b/apps/server/src/voice/voice-context.ts
@@ -6,7 +6,7 @@ export interface VoiceContext {
 interface BuildVoiceContextOptions {
   workDir: string
   environment: string
-  providerHint?: 'anthropic' | 'claude-code'
+  providerHint?: string
 }
 
 const VOICE_RULES = [
@@ -23,13 +23,15 @@ export function buildVoiceContext(
   const { workDir, environment, providerHint } = options
 
   const identityLine =
-    providerHint === 'claude-code'
-      ? 'You are a hands-free voice coding assistant called Voice Claude, powered by Claude Code for code editing and tool use.'
-      : 'You are a hands-free voice coding assistant called Voice Claude.'
+    providerHint === 'opencode'
+      ? 'You are a hands-free voice coding assistant powered by OpenCode.'
+      : providerHint === 'claude-code'
+        ? 'You are a hands-free voice coding assistant called Voice Assistant, powered by Claude Code for code editing and tool use.'
+        : 'You are a hands-free voice coding assistant called Voice Assistant.'
 
   const systemPrompt = `${identityLine} You run as a web app that the user accesses from their phone or computer. You can hear them speak through their microphone — their speech is transcribed and sent to you. Your responses are spoken back to them via text-to-speech. This is a live, real-time voice conversation.
 
-When the user says things like "can you hear me" or "are you there", respond naturally — you can hear them. If they ask what you are, explain that you're Voice Claude, a voice interface that can help with coding tasks hands-free.
+When the user says things like "can you hear me" or "are you there", respond naturally — you can hear them. If they ask what you are, explain that you're Voice Assistant, a voice interface that can help with coding tasks hands-free.
 
 Input is speech-to-text — interpret generously despite transcription errors.
 

--- a/apps/server/src/voice/voice-middleware.ts
+++ b/apps/server/src/voice/voice-middleware.ts
@@ -23,7 +23,7 @@ export interface VoiceInput {
 interface ProcessVoiceInputParams {
   rawText: string
   sessionId: string
-  provider: 'anthropic' | 'claude-code'
+  provider: string
 }
 
 const WORK_DIR = process.env.WORK_DIR ?? process.cwd()

--- a/apps/server/src/ws/audio.ts
+++ b/apps/server/src/ws/audio.ts
@@ -461,6 +461,12 @@ async function handleControl(
 
         finalizeInteraction(sessionId)
       } catch (err) {
+        if (signal.aborted) {
+          log.debug('cancelled during ai call')
+          finalizeInteraction(sessionId)
+          clearAbort()
+          break
+        }
         const message = err instanceof Error ? err.message : 'Unknown error'
         log.error({ err: message }, 'AI error')
         send(ws, { type: 'ai_response', text: '', error: message })

--- a/apps/server/src/ws/audio.ts
+++ b/apps/server/src/ws/audio.ts
@@ -17,7 +17,7 @@ import { chat, clearSession, restoreSession } from '../voice/claude.js'
 import {
   cleanupSession,
   finalizeInteraction,
-  recordClaude,
+  recordLLM,
   recordSTT,
   recordTTS,
 } from '../voice/cost-tracker.js'
@@ -114,7 +114,6 @@ export function attachWebSocket(httpServer: Server) {
             'conversation set',
           )
 
-          // Restore Claude session from persisted messages
           clearSession(sessionId)
           if (conversationId) {
             const conv = await getConversation(conversationId)
@@ -321,7 +320,7 @@ async function handleControl(
       }
 
       // Process voice input through middleware
-      const providerName = getAIProvider().name as 'anthropic' | 'claude-code'
+      const providerName = getAIProvider().name
       const voiceInput = await processVoiceInput({
         rawText: userText,
         sessionId,
@@ -367,7 +366,6 @@ async function handleControl(
         }
       }
 
-      // Phase 2: Send to Claude
       send(ws, { type: 'thinking' })
 
       if (voiceInput.operationalIntents.length > 0) {
@@ -389,7 +387,7 @@ async function handleControl(
           voiceInput.routingHint,
         )
 
-        recordClaude(sessionId, response.usage, response.model)
+        recordLLM(sessionId, response.usage, response.model, providerName)
 
         // Persist assistant message
         if (conversationId) {
@@ -401,10 +399,10 @@ async function handleControl(
         }
 
         if (signal.aborted) {
-          log.debug('cancelled after claude response')
+          log.debug('cancelled after ai response')
           // Still send the response text so it appears in chat, just skip TTS
           send(ws, {
-            type: 'claude_response',
+            type: 'ai_response',
             text: response.text,
             toolCalls: response.toolCalls,
           })
@@ -414,12 +412,11 @@ async function handleControl(
         }
 
         send(ws, {
-          type: 'claude_response',
+          type: 'ai_response',
           text: response.text,
           toolCalls: response.toolCalls,
         })
 
-        // Phase 3: TTS — synthesize Claude's spoken response to audio
         //   Filter out code blocks, inline code, and raw paths first so
         //   we only pay for (and hear) the conversational content.
         const spokenText = response.text ? filterForTTS(response.text) : ''
@@ -458,8 +455,8 @@ async function handleControl(
         finalizeInteraction(sessionId)
       } catch (err) {
         const message = err instanceof Error ? err.message : 'Unknown error'
-        log.error({ err: message }, 'Claude error')
-        send(ws, { type: 'claude_response', text: '', error: message })
+        log.error({ err: message }, 'AI error')
+        send(ws, { type: 'ai_response', text: '', error: message })
         finalizeInteraction(sessionId)
       }
       clearAbort()

--- a/apps/server/src/ws/audio.ts
+++ b/apps/server/src/ws/audio.ts
@@ -394,7 +394,13 @@ async function handleControl(
           voiceInput.routingHint,
         )
 
-        recordLLM(sessionId, response.usage, response.model, providerName)
+        recordLLM(
+          sessionId,
+          response.usage,
+          response.model,
+          response.providerID ?? providerName,
+          response.reportedCost,
+        )
 
         // Persist assistant message
         if (conversationId) {

--- a/apps/web/app/components/chat-message.tsx
+++ b/apps/web/app/components/chat-message.tsx
@@ -144,7 +144,7 @@ export function ChatMessage({
                 : 'text-left text-primary/80'
             }`}
           >
-            {isUser ? 'You' : 'Claude'}
+            {isUser ? 'You' : 'AI'}
           </p>
 
           {/* Message bubble */}

--- a/apps/web/app/components/connection-header.tsx
+++ b/apps/web/app/components/connection-header.tsx
@@ -39,7 +39,7 @@ export function ConnectionHeader({
           </button>
         )}
         <h1 className="text-lg font-semibold tracking-tight text-foreground">
-          Voice Claude
+          Voice
         </h1>
       </div>
       <div className="flex items-center gap-3">

--- a/apps/web/app/hooks/use-audio-socket.ts
+++ b/apps/web/app/hooks/use-audio-socket.ts
@@ -21,8 +21,8 @@ interface AudioSocketState {
   totalBytes: number
   transcription: string | null
   transcriptionError: string | null
-  claudeResponse: string | null
-  claudeError: string | null
+  aiResponse: string | null
+  aiError: string | null
   toolCalls: Array<{ name: string; input: string; result: string }>
   activeTools: string[]
   commandNotice: string | null
@@ -88,8 +88,8 @@ export function useAudioSocket(wsUrl: string | null) {
     totalBytes: 0,
     transcription: null,
     transcriptionError: null,
-    claudeResponse: null,
-    claudeError: null,
+    aiResponse: null,
+    aiError: null,
     toolCalls: [],
     activeTools: [],
     commandNotice: null,
@@ -210,36 +210,36 @@ export function useAudioSocket(wsUrl: string | null) {
           break
 
         case 'thinking':
-          log.debug('claude is thinking')
+          log.debug('ai is thinking')
           setState((s) => ({ ...s, phase: 'thinking' }))
           break
 
         case 'tool_use':
-          log.debug(`claude using tool: ${msg.name}`)
+          log.debug(`ai using tool: ${msg.name}`)
           setState((s) => ({
             ...s,
             activeTools: [...s.activeTools, msg.name],
           }))
           break
 
-        case 'claude_response':
+        case 'ai_response':
           if (msg.error) {
-            log.error(`claude error: ${msg.error}`)
+            log.error(`ai error: ${msg.error}`)
             setState((s) => ({
               ...s,
               phase: 'done',
-              claudeResponse: null,
-              claudeError: msg.error ?? null,
+              aiResponse: null,
+              aiError: msg.error ?? null,
               toolCalls: msg.toolCalls ?? [],
               activeTools: [],
             }))
           } else {
-            log.info(`claude: "${(msg.text ?? '').slice(0, 100)}..."`)
+            log.info(`ai: "${(msg.text ?? '').slice(0, 100)}..."`)
             // Don't set phase to 'done' yet — TTS may follow
             setState((s) => ({
               ...s,
-              claudeResponse: msg.text ?? null,
-              claudeError: null,
+              aiResponse: msg.text ?? null,
+              aiError: null,
               toolCalls: msg.toolCalls ?? [],
               activeTools: [],
             }))
@@ -278,8 +278,8 @@ export function useAudioSocket(wsUrl: string | null) {
             ...(msg.command === 'clear'
               ? {
                   transcription: null,
-                  claudeResponse: null,
-                  claudeError: null,
+                  aiResponse: null,
+                  aiError: null,
                   toolCalls: [],
                 }
               : {}),
@@ -418,8 +418,8 @@ export function useAudioSocket(wsUrl: string | null) {
       totalBytes: 0,
       transcription: null,
       transcriptionError: null,
-      claudeResponse: null,
-      claudeError: null,
+      aiResponse: null,
+      aiError: null,
       toolCalls: [],
       activeTools: [],
       commandNotice: null,

--- a/apps/web/app/routes/costs.tsx
+++ b/apps/web/app/routes/costs.tsx
@@ -16,7 +16,7 @@ interface RootContext {
 
 interface ServiceCosts {
   stt: number
-  claude: number
+  llm: number
   tts: number
 }
 
@@ -41,10 +41,10 @@ interface CostHistory {
   costBreakdown: ServiceCosts
   usage: {
     sttDurationSec: number
-    claudeInputTokens: number
-    claudeOutputTokens: number
-    claudeCacheReadTokens: number
-    claudeCacheWriteTokens: number
+    llmInputTokens: number
+    llmOutputTokens: number
+    llmCacheReadTokens: number
+    llmCacheWriteTokens: number
     ttsChars: number
   }
   byProviderModel: ProviderModelEntry[]
@@ -124,7 +124,7 @@ function periodLabel(period: Period): string {
 
 export function meta() {
   return [
-    { title: 'Costs | Voice Claude' },
+    { title: 'Costs | Voice Assistant' },
     { name: 'description', content: 'API usage costs and breakdown' },
   ]
 }
@@ -341,8 +341,8 @@ export default function Costs() {
               </CardHeader>
               <CardContent className="space-y-4">
                 <CostBar
-                  label="Claude (Anthropic)"
-                  cost={history.costBreakdown.claude}
+                  label="LLM"
+                  cost={history.costBreakdown.llm}
                   total={history.totalCost}
                   color="bg-violet-500"
                 />
@@ -403,19 +403,15 @@ export default function Costs() {
                       </p>
                     </div>
                     <div>
-                      <p className="text-muted-foreground">
-                        Claude Input Tokens
-                      </p>
+                      <p className="text-muted-foreground">LLM Input Tokens</p>
                       <p className="font-mono font-medium">
-                        {formatNumber(history.usage.claudeInputTokens)}
+                        {formatNumber(history.usage.llmInputTokens)}
                       </p>
                     </div>
                     <div>
-                      <p className="text-muted-foreground">
-                        Claude Output Tokens
-                      </p>
+                      <p className="text-muted-foreground">LLM Output Tokens</p>
                       <p className="font-mono font-medium">
-                        {formatNumber(history.usage.claudeOutputTokens)}
+                        {formatNumber(history.usage.llmOutputTokens)}
                       </p>
                     </div>
                   </div>
@@ -429,7 +425,7 @@ export default function Costs() {
                     <div>
                       <p className="text-muted-foreground">Cache Read Tokens</p>
                       <p className="font-mono font-medium">
-                        {formatNumber(history.usage.claudeCacheReadTokens)}
+                        {formatNumber(history.usage.llmCacheReadTokens)}
                       </p>
                     </div>
                     <div>
@@ -437,7 +433,7 @@ export default function Costs() {
                         Cache Write Tokens
                       </p>
                       <p className="font-mono font-medium">
-                        {formatNumber(history.usage.claudeCacheWriteTokens)}
+                        {formatNumber(history.usage.llmCacheWriteTokens)}
                       </p>
                     </div>
                   </div>
@@ -478,7 +474,7 @@ export default function Costs() {
                           </p>
                           <div className="flex gap-2 text-[10px] text-muted-foreground">
                             <span className="text-violet-400">
-                              C:{formatCost(session.costs.claude)}
+                              L:{formatCost(session.costs.llm)}
                             </span>
                             <span className="text-emerald-400">
                               S:{formatCost(session.costs.stt)}

--- a/apps/web/app/routes/home.tsx
+++ b/apps/web/app/routes/home.tsx
@@ -30,10 +30,10 @@ interface ConversationEntry {
 
 export function meta() {
   return [
-    { title: 'Voice Claude' },
+    { title: 'Voice Assistant' },
     {
       name: 'description',
-      content: 'Hands-free voice interface for Claude Code',
+      content: 'Hands-free voice coding assistant',
     },
   ]
 }
@@ -284,24 +284,22 @@ export default function Home() {
     }
   }, [audio.transcription, audio.transcriptionError])
 
-  // When Claude responds, finalize the entry immediately so text appears in chat
   // while TTS audio continues playing in the background.
-  const prevClaudeResponseRef = useRef<string | null>(null)
+  const prevAiResponseRef = useRef<string | null>(null)
   useEffect(() => {
     const hasNewResponse =
-      audio.claudeResponse !== null &&
-      audio.claudeResponse !== prevClaudeResponseRef.current
+      audio.aiResponse !== null &&
+      audio.aiResponse !== prevAiResponseRef.current
 
     const hasNewError =
-      audio.claudeError !== null &&
-      audio.claudeError !== prevClaudeResponseRef.current
+      audio.aiError !== null && audio.aiError !== prevAiResponseRef.current
 
     if ((hasNewResponse || hasNewError) && pendingEntry) {
-      prevClaudeResponseRef.current = audio.claudeResponse ?? audio.claudeError
+      prevAiResponseRef.current = audio.aiResponse ?? audio.aiError
       const finalized: ConversationEntry = {
         ...pendingEntry,
-        assistantText: audio.claudeResponse,
-        assistantError: audio.claudeError,
+        assistantText: audio.aiResponse,
+        assistantError: audio.aiError,
         toolCalls:
           audio.toolCalls.length > 0 ? [...audio.toolCalls] : undefined,
       }
@@ -311,8 +309,8 @@ export default function Home() {
       refreshConversations()
     }
   }, [
-    audio.claudeResponse,
-    audio.claudeError,
+    audio.aiResponse,
+    audio.aiError,
     audio.toolCalls,
     pendingEntry,
     refreshConversations,
@@ -351,10 +349,10 @@ export default function Home() {
       play('messageSent')
     }
 
-    if (curr === 'done' && (audio.transcriptionError || audio.claudeError)) {
+    if (curr === 'done' && (audio.transcriptionError || audio.aiError)) {
       play('error')
     }
-  }, [audio.phase, audio.transcriptionError, audio.claudeError, play])
+  }, [audio.phase, audio.transcriptionError, audio.aiError, play])
 
   // Audio heartbeat during long-running phases (thinking, synthesizing)
   useEffect(() => {

--- a/docs/integration/crush-api-reference.md
+++ b/docs/integration/crush-api-reference.md
@@ -1,0 +1,952 @@
+# Crush Headless HTTP API Reference
+
+**Version**: Based on Crush (successor to OpenCode)  
+**Repository**: https://github.com/charmbracelet/crush  
+**Base Path**: `/v1`
+
+---
+
+## Overview
+
+The Crush headless API provides a complete HTTP interface for programmatic interaction with the AI agent. The API is organized around **workspaces** (project directories) and **sessions** (conversation threads).
+
+### Key Concepts
+
+- **Workspace**: A project directory where the agent operates. Contains sessions, configuration, and file tracking.
+- **Session**: A conversation thread within a workspace. Contains messages exchanged with the AI.
+- **Agent**: The AI assistant that processes prompts and executes tools.
+- **Message**: A single message in a session, with role (user/assistant/system/tool) and content parts.
+- **Events**: Real-time updates via Server-Sent Events (SSE) on workspace changes.
+
+---
+
+## Authentication
+
+**No authentication required** for local development. The API listens on:
+- **Default**: Unix socket at `/tmp/crush-{uid}.sock` (or `crush.sock`)
+- **TCP**: Specify with `--host tcp://127.0.0.1:4096`
+- **Custom**: Use `--host` flag when starting the server
+
+---
+
+## System Endpoints
+
+### Health Check
+```
+GET /v1/health
+```
+**Response**: `200 OK` (empty body)
+
+### Get Server Version
+```
+GET /v1/version
+```
+**Response**:
+```json
+{
+  "version": "0.1.0",
+  "commit": "abc123...",
+  "build_time": "2026-04-08T..."
+}
+```
+
+### Get Server Config
+```
+GET /v1/config
+```
+**Response**: Global server configuration object
+
+### Server Control
+```
+POST /v1/control
+Content-Type: application/json
+
+{
+  "command": "shutdown"
+}
+```
+**Commands**: `shutdown`
+
+---
+
+## Workspace Management
+
+### List All Workspaces
+```
+GET /v1/workspaces
+```
+**Response**:
+```json
+[
+  {
+    "id": "workspace-1",
+    "path": "/home/user/project",
+    "yolo": false,
+    "debug": false,
+    "data_dir": ".crush",
+    "version": "0.1.0",
+    "config": { ... },
+    "env": []
+  }
+]
+```
+
+### Create Workspace
+```
+POST /v1/workspaces
+Content-Type: application/json
+
+{
+  "path": "/home/user/project",
+  "yolo": false,
+  "debug": false,
+  "data_dir": ".crush"
+}
+```
+**Response**: Created workspace object (same structure as list)
+
+### Get Workspace
+```
+GET /v1/workspaces/{id}
+```
+**Response**: Single workspace object
+
+### Delete Workspace
+```
+DELETE /v1/workspaces/{id}
+```
+**Response**: `200 OK`
+
+### Get Workspace Config
+```
+GET /v1/workspaces/{id}/config
+```
+**Response**: Configuration object for the workspace
+
+### Get Workspace Providers
+```
+GET /v1/workspaces/{id}/providers
+```
+**Response**: Available AI providers and their models
+
+### Stream Workspace Events (SSE)
+```
+GET /v1/workspaces/{id}/events
+```
+**Response**: Server-Sent Events stream
+
+**Event Types**:
+- `message` - New message in a session
+- `session` - Session created/updated
+- `file` - File change tracked
+- `lsp_event` - Language Server Protocol event
+- `mcp_event` - Model Context Protocol event
+- `permission_request` - Permission needed for tool execution
+- `permission_notification` - Permission granted/denied
+- `agent_event` - Agent state change
+
+**Example Event**:
+```
+data: {
+  "type": "message",
+  "payload": {
+    "id": "msg-123",
+    "role": "assistant",
+    "session_id": "sess-456",
+    "parts": [...],
+    "model": "claude-3.5-sonnet",
+    "provider": "anthropic",
+    "created_at": 1712600000,
+    "updated_at": 1712600001
+  }
+}
+```
+
+---
+
+## Session Management
+
+### List Sessions in Workspace
+```
+GET /v1/workspaces/{id}/sessions
+```
+**Response**:
+```json
+[
+  {
+    "id": "sess-123",
+    "parent_session_id": "",
+    "title": "Debug authentication flow",
+    "message_count": 5,
+    "prompt_tokens": 1200,
+    "completion_tokens": 450,
+    "summary_message_id": "",
+    "cost": 0.0045,
+    "created_at": 1712600000,
+    "updated_at": 1712600100
+  }
+]
+```
+
+### Create Session
+```
+POST /v1/workspaces/{id}/sessions
+Content-Type: application/json
+
+{
+  "title": "Debug authentication flow"
+}
+```
+**Response**: Created session object
+
+### Get Session
+```
+GET /v1/workspaces/{id}/sessions/{sid}
+```
+**Response**: Single session object
+
+### Update Session
+```
+PUT /v1/workspaces/{id}/sessions/{sid}
+Content-Type: application/json
+
+{
+  "id": "sess-123",
+  "title": "Updated title",
+  "message_count": 5,
+  ...
+}
+```
+**Response**: Updated session object
+
+### Delete Session
+```
+DELETE /v1/workspaces/{id}/sessions/{sid}
+```
+**Response**: `200 OK`
+
+### Get Session Messages
+```
+GET /v1/workspaces/{id}/sessions/{sid}/messages
+```
+**Response**:
+```json
+[
+  {
+    "id": "msg-123",
+    "role": "user",
+    "session_id": "sess-456",
+    "parts": [
+      {
+        "type": "text",
+        "data": {
+          "text": "Explain this code"
+        }
+      }
+    ],
+    "model": "claude-3.5-sonnet",
+    "provider": "anthropic",
+    "created_at": 1712600000,
+    "updated_at": 1712600000
+  },
+  {
+    "id": "msg-124",
+    "role": "assistant",
+    "session_id": "sess-456",
+    "parts": [
+      {
+        "type": "text",
+        "data": {
+          "text": "This code implements..."
+        }
+      }
+    ],
+    "model": "claude-3.5-sonnet",
+    "provider": "anthropic",
+    "created_at": 1712600001,
+    "updated_at": 1712600001
+  }
+]
+```
+
+### Get User Messages Only
+```
+GET /v1/workspaces/{id}/sessions/{sid}/messages/user
+```
+**Response**: Array of messages with role="user"
+
+### Get All User Messages in Workspace
+```
+GET /v1/workspaces/{id}/messages/user
+```
+**Response**: Array of all user messages across all sessions
+
+### Get Session History (File Changes)
+```
+GET /v1/workspaces/{id}/sessions/{sid}/history
+```
+**Response**:
+```json
+[
+  {
+    "id": "file-123",
+    "session_id": "sess-456",
+    "path": "src/auth.ts",
+    "content": "...",
+    "version": 1,
+    "created_at": 1712600000
+  }
+]
+```
+
+---
+
+## Agent & Prompts
+
+### Get Agent Info
+```
+GET /v1/workspaces/{id}/agent
+```
+**Response**:
+```json
+{
+  "is_busy": false,
+  "is_ready": true,
+  "model": {
+    "id": "claude-3.5-sonnet",
+    "name": "Claude 3.5 Sonnet",
+    "provider": "anthropic",
+    "context_window": 200000,
+    "max_output_tokens": 4096
+  },
+  "model_cfg": {
+    "provider": "anthropic",
+    "model": "claude-3.5-sonnet",
+    "max_tokens": 4096
+  }
+}
+```
+
+### Initialize Agent
+```
+POST /v1/workspaces/{id}/agent/init
+```
+**Response**: `200 OK`
+
+### Update Agent
+```
+POST /v1/workspaces/{id}/agent/update
+```
+**Response**: `200 OK`
+
+### Send Message to Agent (Async)
+```
+POST /v1/workspaces/{id}/agent
+Content-Type: application/json
+
+{
+  "session_id": "sess-123",
+  "prompt": "Explain how this authentication works",
+  "attachments": [
+    {
+      "file_path": "src/auth.ts",
+      "file_name": "auth.ts",
+      "mime_type": "text/plain",
+      "content": "base64-encoded-content"
+    }
+  ]
+}
+```
+**Response**: `200 OK`
+
+**Notes**:
+- This is **asynchronous** — the agent processes the prompt in the background
+- Monitor progress via the SSE `/events` endpoint
+- Messages are added to the session's message list as they arrive
+- The agent will emit `message` events as it generates responses
+
+### Get Agent Session
+```
+GET /v1/workspaces/{id}/agent/sessions/{sid}
+```
+**Response**:
+```json
+{
+  "id": "sess-123",
+  "title": "Debug auth",
+  "message_count": 5,
+  "prompt_tokens": 1200,
+  "completion_tokens": 450,
+  "summary_message_id": "",
+  "cost": 0.0045,
+  "created_at": 1712600000,
+  "updated_at": 1712600100,
+  "is_busy": false
+}
+```
+
+### Cancel Agent Session
+```
+POST /v1/workspaces/{id}/agent/sessions/{sid}/cancel
+```
+**Response**: `200 OK`
+
+### Get Queued Prompt Status
+```
+GET /v1/workspaces/{id}/agent/sessions/{sid}/prompts/queued
+```
+**Response**:
+```json
+{
+  "has_queued": true,
+  "count": 1
+}
+```
+
+### List Queued Prompts
+```
+GET /v1/workspaces/{id}/agent/sessions/{sid}/prompts/list
+```
+**Response**:
+```json
+[
+  "First queued prompt text",
+  "Second queued prompt text"
+]
+```
+
+### Clear Prompt Queue
+```
+POST /v1/workspaces/{id}/agent/sessions/{sid}/prompts/clear
+```
+**Response**: `200 OK`
+
+### Summarize Session
+```
+POST /v1/workspaces/{id}/agent/sessions/{sid}/summarize
+```
+**Response**: `200 OK`
+
+**Notes**:
+- Creates a new session with a summary of the current session
+- Useful for managing context window limits
+
+### Get Default Small Model
+```
+GET /v1/workspaces/{id}/agent/default-small-model?provider_id=anthropic
+```
+**Response**:
+```json
+{
+  "id": "claude-3.5-haiku",
+  "name": "Claude 3.5 Haiku",
+  "provider": "anthropic"
+}
+```
+
+---
+
+## File Tracking
+
+### Get Tracked Files for Session
+```
+GET /v1/workspaces/{id}/sessions/{sid}/filetracker/files
+```
+**Response**:
+```json
+[
+  "src/auth.ts",
+  "src/utils.ts"
+]
+```
+
+### Record File Read
+```
+POST /v1/workspaces/{id}/filetracker/read
+Content-Type: application/json
+
+{
+  "session_id": "sess-123",
+  "path": "src/auth.ts"
+}
+```
+**Response**: `200 OK`
+
+### Get Last Read Time for File
+```
+GET /v1/workspaces/{id}/filetracker/lastread?session_id=sess-123&path=src/auth.ts
+```
+**Response**:
+```json
+{
+  "last_read": 1712600000
+}
+```
+
+---
+
+## Language Server Protocol (LSP)
+
+### List LSP Clients
+```
+GET /v1/workspaces/{id}/lsps
+```
+**Response**:
+```json
+{
+  "go": {
+    "name": "gopls",
+    "state": "connected",
+    "error": "",
+    "diagnostic_count": 2,
+    "connected_at": "2026-04-08T12:00:00Z"
+  },
+  "typescript": {
+    "name": "typescript-language-server",
+    "state": "connected",
+    "error": "",
+    "diagnostic_count": 0,
+    "connected_at": "2026-04-08T12:00:00Z"
+  }
+}
+```
+
+### Get LSP Diagnostics
+```
+GET /v1/workspaces/{id}/lsps/{lsp}/diagnostics
+```
+**Response**: Diagnostics object from the LSP server
+
+### Start LSP Server
+```
+POST /v1/workspaces/{id}/lsps/start
+Content-Type: application/json
+
+{
+  "path": "/home/user/project"
+}
+```
+**Response**: `200 OK`
+
+### Stop All LSP Servers
+```
+POST /v1/workspaces/{id}/lsps/stop
+```
+**Response**: `200 OK`
+
+---
+
+## Permissions
+
+### Get Skip Permissions Status
+```
+GET /v1/workspaces/{id}/permissions/skip
+```
+**Response**:
+```json
+{
+  "skip": false
+}
+```
+
+### Set Skip Permissions
+```
+POST /v1/workspaces/{id}/permissions/skip
+Content-Type: application/json
+
+{
+  "skip": true
+}
+```
+**Response**: `200 OK`
+
+### Grant Permission
+```
+POST /v1/workspaces/{id}/permissions/grant
+Content-Type: application/json
+
+{
+  "permission": {
+    "id": "perm-123",
+    "session_id": "sess-456",
+    "tool_call_id": "tool-789",
+    "tool_name": "bash",
+    "description": "Execute: rm -rf /",
+    "action": "execute",
+    "path": "/",
+    "params": {}
+  },
+  "action": "allow"
+}
+```
+**Response**: `200 OK`
+
+**Permission Actions**:
+- `allow` - Allow this specific tool call
+- `allow_session` - Allow all calls to this tool in this session
+- `deny` - Deny this tool call
+
+---
+
+## Configuration
+
+### Set Config Value
+```
+POST /v1/workspaces/{id}/config/set
+Content-Type: application/json
+
+{
+  "key": "some_key",
+  "value": "some_value"
+}
+```
+**Response**: `200 OK`
+
+### Remove Config Value
+```
+POST /v1/workspaces/{id}/config/remove
+Content-Type: application/json
+
+{
+  "key": "some_key"
+}
+```
+**Response**: `200 OK`
+
+### Set Model
+```
+POST /v1/workspaces/{id}/config/model
+Content-Type: application/json
+
+{
+  "provider": "anthropic",
+  "model": "claude-3.5-sonnet",
+  "max_tokens": 4096
+}
+```
+**Response**: `200 OK`
+
+### Set Provider API Key
+```
+POST /v1/workspaces/{id}/config/provider-key
+Content-Type: application/json
+
+{
+  "provider": "anthropic",
+  "api_key": "sk-ant-..."
+}
+```
+**Response**: `200 OK`
+
+### Enable Auto-Compact
+```
+POST /v1/workspaces/{id}/config/compact
+Content-Type: application/json
+
+{
+  "enabled": true,
+  "threshold": 0.95
+}
+```
+**Response**: `200 OK`
+
+---
+
+## Model Context Protocol (MCP)
+
+### Refresh MCP Tools
+```
+POST /v1/workspaces/{id}/mcp/refresh-tools
+```
+**Response**: `200 OK`
+
+### Read MCP Resource
+```
+POST /v1/workspaces/{id}/mcp/read-resource
+Content-Type: application/json
+
+{
+  "uri": "file:///path/to/resource"
+}
+```
+**Response**: Resource content
+
+### Get MCP Prompt
+```
+POST /v1/workspaces/{id}/mcp/get-prompt
+Content-Type: application/json
+
+{
+  "name": "prompt-name",
+  "arguments": {}
+}
+```
+**Response**: Prompt content
+
+### Get MCP States
+```
+GET /v1/workspaces/{id}/mcp/states
+```
+**Response**: State of all MCP servers
+
+### Refresh MCP Prompts
+```
+POST /v1/workspaces/{id}/mcp/refresh-prompts
+```
+**Response**: `200 OK`
+
+### Refresh MCP Resources
+```
+POST /v1/workspaces/{id}/mcp/refresh-resources
+```
+**Response**: `200 OK`
+
+### Enable Docker for MCP
+```
+POST /v1/workspaces/{id}/mcp/docker/enable
+```
+**Response**: `200 OK`
+
+### Disable Docker for MCP
+```
+POST /v1/workspaces/{id}/mcp/docker/disable
+```
+**Response**: `200 OK`
+
+---
+
+## Project Initialization
+
+### Check if Project Needs Init
+```
+GET /v1/workspaces/{id}/project/needs-init
+```
+**Response**:
+```json
+{
+  "needs_init": true
+}
+```
+
+### Initialize Project
+```
+POST /v1/workspaces/{id}/project/init
+```
+**Response**: `200 OK`
+
+### Get Project Init Prompt
+```
+GET /v1/workspaces/{id}/project/init-prompt
+```
+**Response**: Suggested initialization prompt
+
+---
+
+## Complete Example: Voice-Claude Integration
+
+### 1. Create Workspace
+```bash
+curl -X POST http://localhost:4096/v1/workspaces \
+  -H "Content-Type: application/json" \
+  -d '{
+    "path": "/home/user/my-project",
+    "yolo": false,
+    "debug": false
+  }'
+```
+
+### 2. Create Session
+```bash
+curl -X POST http://localhost:4096/v1/workspaces/{workspace-id}/sessions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "title": "Voice session"
+  }'
+```
+
+### 3. Subscribe to Events (in background)
+```bash
+curl -N http://localhost:4096/v1/workspaces/{workspace-id}/events
+```
+
+### 4. Send Transcribed Speech as Prompt
+```bash
+curl -X POST http://localhost:4096/v1/workspaces/{workspace-id}/agent \
+  -H "Content-Type: application/json" \
+  -d '{
+    "session_id": "{session-id}",
+    "prompt": "Explain how authentication works in this codebase"
+  }'
+```
+
+### 5. Listen for Response Messages
+The SSE stream will emit `message` events with the assistant's response:
+```json
+{
+  "type": "message",
+  "payload": {
+    "id": "msg-456",
+    "role": "assistant",
+    "session_id": "{session-id}",
+    "parts": [
+      {
+        "type": "text",
+        "data": {
+          "text": "Authentication in this codebase uses JWT tokens..."
+        }
+      }
+    ],
+    "created_at": 1712600001
+  }
+}
+```
+
+### 6. Extract Text and Feed to TTS
+```javascript
+// From the message event payload
+const textContent = message.parts.find(p => p.type === 'text');
+const responseText = textContent.data.text;
+
+// Send to TTS service (e.g., OpenAI TTS, ElevenLabs)
+const audioBuffer = await ttsService.synthesize(responseText);
+
+// Play through earbuds
+audioPlayer.play(audioBuffer);
+```
+
+---
+
+## Message Content Parts
+
+Messages can contain multiple content parts. Each part has a `type` and `data`:
+
+### Text Content
+```json
+{
+  "type": "text",
+  "data": {
+    "text": "The response text"
+  }
+}
+```
+
+### Reasoning Content (Extended Thinking)
+```json
+{
+  "type": "reasoning",
+  "data": {
+    "thinking": "Let me think about this...",
+    "signature": "...",
+    "started_at": 1712600000,
+    "finished_at": 1712600001
+  }
+}
+```
+
+### Tool Call
+```json
+{
+  "type": "tool_call",
+  "data": {
+    "id": "tool-call-123",
+    "name": "bash",
+    "input": "{\"command\": \"ls -la\"}",
+    "type": "function",
+    "finished": false
+  }
+}
+```
+
+### Tool Result
+```json
+{
+  "type": "tool_result",
+  "data": {
+    "tool_call_id": "tool-call-123",
+    "name": "bash",
+    "content": "total 48\ndrwxr-xr-x  5 user  staff  160 Apr  8 12:00 .",
+    "metadata": "",
+    "is_error": false
+  }
+}
+```
+
+### Image URL
+```json
+{
+  "type": "image_url",
+  "data": {
+    "url": "https://example.com/image.png",
+    "detail": "high"
+  }
+}
+```
+
+### Finish (End of Message)
+```json
+{
+  "type": "finish",
+  "data": {
+    "reason": "end_turn",
+    "time": 1712600002,
+    "message": "Completed successfully",
+    "details": ""
+  }
+}
+```
+
+**Finish Reasons**:
+- `end_turn` - Normal completion
+- `max_tokens` - Hit token limit
+- `tool_use` - Waiting for tool results
+- `canceled` - User canceled
+- `error` - Error occurred
+- `permission_denied` - Permission denied
+- `unknown` - Unknown reason
+
+---
+
+## Error Responses
+
+All errors return JSON with status code and message:
+
+```json
+{
+  "message": "Workspace not found"
+}
+```
+
+**Common Status Codes**:
+- `400` - Bad request (invalid JSON, missing fields)
+- `404` - Not found (workspace, session, etc.)
+- `500` - Internal server error
+
+---
+
+## Notes for voice-claude Integration
+
+1. **Async Processing**: The `/agent` endpoint is asynchronous. Use SSE `/events` to monitor progress.
+
+2. **Response Streaming**: Messages are streamed as they're generated. Listen for `message` events with `role: "assistant"`.
+
+3. **Tool Execution**: If the agent calls tools (bash, file operations), you'll see:
+   - `tool_call` part in the message
+   - `permission_request` event (if permissions not auto-approved)
+   - `tool_result` part with the tool output
+
+4. **Session Persistence**: All messages are saved to the session. You can retrieve them later with `GET /sessions/{sid}/messages`.
+
+5. **File Attachments**: Send files with the prompt using the `attachments` field in `AgentMessage`.
+
+6. **Polling Alternative**: If SSE is unavailable, poll `GET /sessions/{sid}/messages` periodically to check for new messages.
+
+---
+
+## Swagger/OpenAPI Documentation
+
+Full API documentation is available at:
+```
+GET /v1/docs/
+```
+
+This serves the Swagger UI with interactive API exploration.

--- a/docs/integration/crush-api-summary.md
+++ b/docs/integration/crush-api-summary.md
@@ -1,0 +1,295 @@
+# Crush Headless API Summary
+
+## What You Need to Know
+
+The **Crush headless API** (successor to OpenCode) provides a complete HTTP interface for building voice-enabled AI assistants. It's designed for exactly what you're building: transcribed speech → AI processing → text response → TTS playback.
+
+---
+
+## The Complete API Surface
+
+### System (4 endpoints)
+- `GET /v1/health` — Health check
+- `GET /v1/version` — Server version
+- `GET /v1/config` — Global config
+- `POST /v1/control` — Server control (shutdown)
+
+### Workspaces (6 endpoints)
+- `GET /v1/workspaces` — List all
+- `POST /v1/workspaces` — Create
+- `GET /v1/workspaces/{id}` — Get one
+- `DELETE /v1/workspaces/{id}` — Delete
+- `GET /v1/workspaces/{id}/config` — Get config
+- `GET /v1/workspaces/{id}/providers` — List providers
+- `GET /v1/workspaces/{id}/events` — **Stream events (SSE)**
+
+### Sessions (7 endpoints)
+- `GET /v1/workspaces/{id}/sessions` — List
+- `POST /v1/workspaces/{id}/sessions` — Create
+- `GET /v1/workspaces/{id}/sessions/{sid}` — Get one
+- `PUT /v1/workspaces/{id}/sessions/{sid}` — Update
+- `DELETE /v1/workspaces/{id}/sessions/{sid}` — Delete
+- `GET /v1/workspaces/{id}/sessions/{sid}/messages` — Get all messages
+- `GET /v1/workspaces/{id}/sessions/{sid}/history` — Get file changes
+
+### Agent & Prompts (11 endpoints) ⭐ **MOST IMPORTANT FOR VOICE**
+- `GET /v1/workspaces/{id}/agent` — Get agent status
+- `POST /v1/workspaces/{id}/agent` — **Send prompt (async)**
+- `POST /v1/workspaces/{id}/agent/init` — Initialize agent
+- `POST /v1/workspaces/{id}/agent/update` — Update agent
+- `GET /v1/workspaces/{id}/agent/sessions/{sid}` — Get session status
+- `POST /v1/workspaces/{id}/agent/sessions/{sid}/cancel` — Cancel
+- `GET /v1/workspaces/{id}/agent/sessions/{sid}/prompts/queued` — Check queue
+- `GET /v1/workspaces/{id}/agent/sessions/{sid}/prompts/list` — List queued
+- `POST /v1/workspaces/{id}/agent/sessions/{sid}/prompts/clear` — Clear queue
+- `POST /v1/workspaces/{id}/agent/sessions/{sid}/summarize` — Summarize
+- `GET /v1/workspaces/{id}/agent/default-small-model` — Get small model
+
+### File Tracking (3 endpoints)
+- `GET /v1/workspaces/{id}/sessions/{sid}/filetracker/files` — List tracked
+- `POST /v1/workspaces/{id}/filetracker/read` — Record read
+- `GET /v1/workspaces/{id}/filetracker/lastread` — Get last read time
+
+### LSP (4 endpoints)
+- `GET /v1/workspaces/{id}/lsps` — List LSP clients
+- `GET /v1/workspaces/{id}/lsps/{lsp}/diagnostics` — Get diagnostics
+- `POST /v1/workspaces/{id}/lsps/start` — Start LSP
+- `POST /v1/workspaces/{id}/lsps/stop` — Stop all LSP
+
+### Permissions (3 endpoints)
+- `GET /v1/workspaces/{id}/permissions/skip` — Get skip status
+- `POST /v1/workspaces/{id}/permissions/skip` — Set skip
+- `POST /v1/workspaces/{id}/permissions/grant` — Grant permission
+
+### Configuration (5 endpoints)
+- `POST /v1/workspaces/{id}/config/set` — Set value
+- `POST /v1/workspaces/{id}/config/remove` — Remove value
+- `POST /v1/workspaces/{id}/config/model` — Set model
+- `POST /v1/workspaces/{id}/config/provider-key` — Set API key
+- `POST /v1/workspaces/{id}/config/compact` — Enable auto-compact
+
+### MCP (8 endpoints)
+- `POST /v1/workspaces/{id}/mcp/refresh-tools` — Refresh tools
+- `POST /v1/workspaces/{id}/mcp/read-resource` — Read resource
+- `POST /v1/workspaces/{id}/mcp/get-prompt` — Get prompt
+- `GET /v1/workspaces/{id}/mcp/states` — Get states
+- `POST /v1/workspaces/{id}/mcp/refresh-prompts` — Refresh prompts
+- `POST /v1/workspaces/{id}/mcp/refresh-resources` — Refresh resources
+- `POST /v1/workspaces/{id}/mcp/docker/enable` — Enable Docker
+- `POST /v1/workspaces/{id}/mcp/docker/disable` — Disable Docker
+
+### Project (3 endpoints)
+- `GET /v1/workspaces/{id}/project/needs-init` — Check init status
+- `POST /v1/workspaces/{id}/project/init` — Initialize
+- `GET /v1/workspaces/{id}/project/init-prompt` — Get init prompt
+
+**Total: 68 endpoints**
+
+---
+
+## The Voice Loop (What You Actually Need)
+
+For voice-claude, you only need **5 endpoints**:
+
+```
+1. POST /v1/workspaces                    → Create workspace
+2. POST /v1/workspaces/{id}/sessions      → Create session
+3. GET  /v1/workspaces/{id}/events        → Stream events (SSE)
+4. POST /v1/workspaces/{id}/agent         → Send prompt
+5. GET  /v1/workspaces/{id}/sessions/{sid}/messages → Get messages (fallback)
+```
+
+### The Flow
+
+```
+User speaks
+    ↓
+STT (Whisper) → "Explain authentication"
+    ↓
+POST /agent with prompt
+    ↓
+Agent processes (async, in background)
+    ↓
+SSE /events emits "message" events
+    ↓
+Extract text from message.parts[].data.text
+    ↓
+TTS (OpenAI/ElevenLabs) → audio
+    ↓
+Play through earbuds
+```
+
+---
+
+## Key Insights
+
+### 1. **Async Processing**
+- `POST /agent` returns `200 OK` immediately
+- Agent processes in background
+- Results stream via SSE `/events`
+- No polling needed (unless SSE unavailable)
+
+### 2. **Message Structure**
+Every message has:
+```json
+{
+  "id": "msg-123",
+  "role": "assistant",  // or "user", "system", "tool"
+  "session_id": "sess-456",
+  "parts": [
+    {
+      "type": "text",
+      "data": { "text": "The response" }
+    },
+    {
+      "type": "finish",
+      "data": { "reason": "end_turn" }
+    }
+  ],
+  "model": "claude-3.5-sonnet",
+  "provider": "anthropic",
+  "created_at": 1712600000
+}
+```
+
+### 3. **Content Parts**
+Messages can contain multiple parts:
+- `text` — The actual response (what you feed to TTS)
+- `tool_call` — Agent calling bash/file operations
+- `tool_result` — Output from tool execution
+- `reasoning` — Extended thinking (if enabled)
+- `finish` — End of message (signals completion)
+
+### 4. **Event Types**
+The SSE stream emits:
+- `message` — New message (most important for voice)
+- `session` — Session updated
+- `file` — File changed
+- `permission_request` — Need approval for tool
+- `permission_notification` — Permission granted/denied
+- `lsp_event` — Language server event
+- `mcp_event` — MCP server event
+- `agent_event` — Agent state change
+
+### 5. **No Authentication**
+- Local development: no auth required
+- Listens on Unix socket or TCP port
+- Start with: `crush serve --host tcp://127.0.0.1:4096`
+
+---
+
+## Response Formats
+
+### Success (200 OK)
+```json
+{
+  "id": "msg-123",
+  "role": "assistant",
+  "parts": [...]
+}
+```
+
+### Error (400/404/500)
+```json
+{
+  "message": "Workspace not found"
+}
+```
+
+---
+
+## For voice-claude Implementation
+
+### Minimal Setup
+```javascript
+// 1. Create workspace
+const ws = await fetch('http://localhost:4096/v1/workspaces', {
+  method: 'POST',
+  body: JSON.stringify({ path: '/project' })
+}).then(r => r.json());
+
+// 2. Create session
+const sess = await fetch(`http://localhost:4096/v1/workspaces/${ws.id}/sessions`, {
+  method: 'POST',
+  body: JSON.stringify({ title: 'Voice' })
+}).then(r => r.json());
+
+// 3. Subscribe to events
+const eventSource = new EventSource(
+  `http://localhost:4096/v1/workspaces/${ws.id}/events`
+);
+eventSource.onmessage = (e) => {
+  const event = JSON.parse(e.data);
+  if (event.type === 'message' && event.payload.role === 'assistant') {
+    const text = event.payload.parts
+      .find(p => p.type === 'text')?.data.text;
+    if (text) {
+      // Feed to TTS
+      ttsService.synthesize(text).then(audio => audioPlayer.play(audio));
+    }
+  }
+};
+
+// 4. Send prompt
+await fetch(`http://localhost:4096/v1/workspaces/${ws.id}/agent`, {
+  method: 'POST',
+  body: JSON.stringify({
+    session_id: sess.id,
+    prompt: transcribedText
+  })
+});
+```
+
+---
+
+## What's NOT in the API
+
+- **No WebSocket** — Uses HTTP + SSE instead
+- **No authentication** — Local only
+- **No rate limiting** — Not needed for local
+- **No file upload endpoint** — Use `attachments` in prompt
+- **No streaming request body** — Send complete prompt
+
+---
+
+## Comparison: OpenCode vs Crush
+
+| Feature | OpenCode | Crush |
+|---------|----------|-------|
+| Status | Archived | Active ✓ |
+| Headless API | No | Yes ✓ |
+| HTTP Endpoints | No | 68 ✓ |
+| SSE Events | No | Yes ✓ |
+| Repository | sst/opencode | charmbracelet/crush |
+
+**Use Crush** — it's the maintained successor with the headless API you need.
+
+---
+
+## Related Documentation
+
+1. **crush-api-reference.md** — Complete endpoint documentation
+2. **crush-integration-guide.md** — Step-by-step integration guide
+3. **crush-api-summary.md** — This file
+
+---
+
+## Next Steps
+
+1. Start Crush server: `crush serve --host tcp://127.0.0.1:4096`
+2. Implement the 5-endpoint voice loop
+3. Test with curl first, then integrate into voice-claude
+4. Monitor SSE events for responses
+5. Extract text and feed to TTS
+
+---
+
+## Source Code References
+
+All endpoints are defined in:
+- **Server routes**: `/tmp/crush/internal/server/server.go` (lines 109-168)
+- **Handler implementations**: `/tmp/crush/internal/server/proto.go` (969 lines)
+- **Type definitions**: `/tmp/crush/internal/proto/*.go`
+- **Event wrapping**: `/tmp/crush/internal/server/events.go`
+
+Repository: https://github.com/charmbracelet/crush

--- a/docs/integration/crush-integration-guide.md
+++ b/docs/integration/crush-integration-guide.md
@@ -1,0 +1,323 @@
+# Crush Headless API Integration Guide
+
+## Quick Start for voice-claude
+
+### 1. Start the Crush Server
+```bash
+# On your Mac (or wherever the server runs)
+crush serve --host tcp://127.0.0.1:4096
+```
+
+### 2. Create a Workspace
+```bash
+curl -X POST http://localhost:4096/v1/workspaces \
+  -H "Content-Type: application/json" \
+  -d '{
+    "path": "/path/to/your/project",
+    "yolo": false,
+    "debug": false
+  }'
+# Returns: { "id": "workspace-abc123", ... }
+```
+
+### 3. Create a Session
+```bash
+curl -X POST http://localhost:4096/v1/workspaces/workspace-abc123/sessions \
+  -H "Content-Type: application/json" \
+  -d '{"title": "Voice session"}'
+# Returns: { "id": "sess-xyz789", ... }
+```
+
+### 4. Subscribe to Events (in background)
+```bash
+# This streams all events for the workspace
+curl -N http://localhost:4096/v1/workspaces/workspace-abc123/events
+```
+
+### 5. Send Transcribed Speech as Prompt
+```bash
+curl -X POST http://localhost:4096/v1/workspaces/workspace-abc123/agent \
+  -H "Content-Type: application/json" \
+  -d '{
+    "session_id": "sess-xyz789",
+    "prompt": "Explain how authentication works in this codebase"
+  }'
+```
+
+### 6. Listen for Response in Event Stream
+The event stream will emit messages like:
+```json
+{
+  "type": "message",
+  "payload": {
+    "id": "msg-456",
+    "role": "assistant",
+    "session_id": "sess-xyz789",
+    "parts": [
+      {
+        "type": "text",
+        "data": {
+          "text": "Authentication in this codebase uses JWT tokens..."
+        }
+      }
+    ]
+  }
+}
+```
+
+### 7. Extract Text and Feed to TTS
+```javascript
+// Parse the message event
+const message = JSON.parse(event.data).payload;
+const textPart = message.parts.find(p => p.type === 'text');
+const responseText = textPart.data.text;
+
+// Send to TTS (OpenAI, ElevenLabs, etc.)
+const audio = await ttsService.synthesize(responseText);
+
+// Play through earbuds
+audioPlayer.play(audio);
+```
+
+---
+
+## Key API Endpoints for voice-claude
+
+| Endpoint | Method | Purpose |
+|----------|--------|---------|
+| `/v1/workspaces` | POST | Create workspace |
+| `/v1/workspaces/{id}/sessions` | POST | Create session |
+| `/v1/workspaces/{id}/events` | GET | Stream events (SSE) |
+| `/v1/workspaces/{id}/agent` | POST | Send prompt to agent |
+| `/v1/workspaces/{id}/sessions/{sid}/messages` | GET | Get all messages |
+| `/v1/workspaces/{id}/agent/sessions/{sid}` | GET | Get session status |
+
+---
+
+## Response Flow
+
+```
+User speaks
+    ↓
+STT (Whisper/Google) → transcribed text
+    ↓
+POST /agent with prompt
+    ↓
+Agent processes (async)
+    ↓
+SSE /events stream emits "message" events
+    ↓
+Extract text from message.parts[].data.text
+    ↓
+TTS (OpenAI/ElevenLabs) → audio
+    ↓
+Play through earbuds
+```
+
+---
+
+## Message Structure
+
+Every message has:
+- `id`: Unique message ID
+- `role`: "user", "assistant", "system", or "tool"
+- `session_id`: Which session it belongs to
+- `parts`: Array of content parts
+- `model`: Which model generated it
+- `provider`: Which provider (anthropic, openai, etc.)
+- `created_at`: Unix timestamp
+
+### Content Parts
+
+Each part in `parts[]` has `type` and `data`:
+
+**Text** (most common for voice):
+```json
+{
+  "type": "text",
+  "data": { "text": "The response" }
+}
+```
+
+**Tool Call** (if agent executes bash/file ops):
+```json
+{
+  "type": "tool_call",
+  "data": {
+    "id": "tool-123",
+    "name": "bash",
+    "input": "{\"command\": \"ls -la\"}"
+  }
+}
+```
+
+**Tool Result** (output from tool):
+```json
+{
+  "type": "tool_result",
+  "data": {
+    "tool_call_id": "tool-123",
+    "name": "bash",
+    "content": "total 48\ndrwxr-xr-x..."
+  }
+}
+```
+
+**Finish** (end of message):
+```json
+{
+  "type": "finish",
+  "data": {
+    "reason": "end_turn",
+    "time": 1712600002
+  }
+}
+```
+
+---
+
+## Async Processing Model
+
+The `/agent` endpoint is **asynchronous**:
+
+1. **POST /agent** → Returns `200 OK` immediately
+2. **Agent processes** in background
+3. **SSE stream** emits `message` events as they're generated
+4. **Message parts** arrive incrementally (streaming)
+5. **Finish part** signals completion
+
+### Detecting Completion
+
+Listen for a `message` event where the last part has `type: "finish"`:
+
+```javascript
+const isComplete = message.parts.some(p => p.type === 'finish');
+if (isComplete) {
+  // Message is done, safe to extract full text
+  const text = message.parts
+    .filter(p => p.type === 'text')
+    .map(p => p.data.text)
+    .join('');
+}
+```
+
+---
+
+## Polling Alternative (if SSE unavailable)
+
+If your environment doesn't support SSE, poll for messages:
+
+```bash
+# Poll every 500ms
+while true; do
+  curl -s http://localhost:4096/v1/workspaces/{id}/sessions/{sid}/messages \
+    | jq '.[-1]'  # Get latest message
+  sleep 0.5
+done
+```
+
+---
+
+## Error Handling
+
+All errors return JSON:
+```json
+{
+  "message": "Workspace not found"
+}
+```
+
+**Status Codes**:
+- `200` - Success
+- `400` - Bad request (invalid JSON, missing fields)
+- `404` - Not found (workspace, session, etc.)
+- `500` - Server error
+
+---
+
+## Configuration
+
+### Set Model
+```bash
+curl -X POST http://localhost:4096/v1/workspaces/{id}/config/model \
+  -H "Content-Type: application/json" \
+  -d '{
+    "provider": "anthropic",
+    "model": "claude-3.5-sonnet",
+    "max_tokens": 4096
+  }'
+```
+
+### Set API Key
+```bash
+curl -X POST http://localhost:4096/v1/workspaces/{id}/config/provider-key \
+  -H "Content-Type: application/json" \
+  -d '{
+    "provider": "anthropic",
+    "api_key": "sk-ant-..."
+  }'
+```
+
+### Skip Permissions (auto-approve tool execution)
+```bash
+curl -X POST http://localhost:4096/v1/workspaces/{id}/permissions/skip \
+  -H "Content-Type: application/json" \
+  -d '{"skip": true}'
+```
+
+---
+
+## Implementation Checklist for voice-claude
+
+- [ ] Start Crush server on port 4096
+- [ ] Create workspace for project
+- [ ] Create session for voice conversation
+- [ ] Set up SSE event listener
+- [ ] Implement prompt submission (POST /agent)
+- [ ] Parse message events from SSE stream
+- [ ] Extract text from message.parts
+- [ ] Detect message completion (finish part)
+- [ ] Feed text to TTS service
+- [ ] Play audio through earbuds
+- [ ] Handle tool execution (if needed)
+- [ ] Handle permission requests (if needed)
+- [ ] Implement error handling
+- [ ] Test end-to-end flow
+
+---
+
+## Full API Reference
+
+See `crush-api-reference.md` for complete endpoint documentation.
+
+---
+
+## Troubleshooting
+
+### "Workspace not found"
+- Verify workspace ID from creation response
+- Check workspace exists: `GET /v1/workspaces`
+
+### No events in SSE stream
+- Verify event stream is connected: `curl -N http://localhost:4096/v1/workspaces/{id}/events`
+- Check for network issues
+- Verify workspace ID is correct
+
+### Agent not responding
+- Check agent is ready: `GET /v1/workspaces/{id}/agent`
+- Verify API key is set: `POST /config/provider-key`
+- Check permissions: `GET /v1/workspaces/{id}/permissions/skip`
+
+### Tool execution fails
+- Check permissions: `GET /v1/workspaces/{id}/permissions/skip`
+- Grant permission: `POST /v1/workspaces/{id}/permissions/grant`
+- Check tool output in `tool_result` part
+
+---
+
+## Performance Notes
+
+- **Latency**: STT + API + TTS should stay under 3-4 seconds for good UX
+- **Streaming**: Messages arrive incrementally, start playing TTS as soon as you have text
+- **Buffering**: Buffer text parts until you see a `finish` part
+- **Concurrency**: One prompt at a time per session (queue additional prompts)

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -100,14 +100,14 @@ export const toolUseMessage = z.object({
 
 export type ToolUseMessage = z.infer<typeof toolUseMessage>
 
-export const claudeResponseMessage = z.object({
-  type: z.literal('claude_response'),
+export const aiResponseMessage = z.object({
+  type: z.literal('ai_response'),
   text: z.string().optional(),
   error: z.string().optional(),
   toolCalls: z.array(toolCallSchema).optional(),
 })
 
-export type ClaudeResponseMessage = z.infer<typeof claudeResponseMessage>
+export type AIResponseMessage = z.infer<typeof aiResponseMessage>
 
 export const synthesizingMessage = z.object({
   type: z.literal('synthesizing'),
@@ -143,7 +143,7 @@ export const serverWsMessage = z.discriminatedUnion('type', [
   transcriptionMessage,
   thinkingMessage,
   toolUseMessage,
-  claudeResponseMessage,
+  aiResponseMessage,
   synthesizingMessage,
   ttsAudioMessage,
   ttsErrorMessage,


### PR DESCRIPTION
## Summary

- Adds `AI_PROVIDER=opencode` option that routes the voice pipeline through opencode's headless HTTP API (`opencode serve` / `coda serve`), enabling multi-provider support — whatever models opencode is configured with become available to the voice pipeline
- Generalizes all Claude-specific naming to provider-agnostic terms across server, contracts, and web client
- Keeps existing `anthropic` and `claude-code` providers fully functional

## What changed

### New: OpenCode Provider (`apps/server/src/voice/opencode-provider.ts`)
- Implements the `AIProvider` interface using raw `fetch()` (zero new dependencies)
- Creates opencode sessions on demand, maps voice session IDs → opencode session IDs with 30-min TTL eviction
- Prepends `[VOICE MODE]` rules to user messages (since opencode manages its own system prompts via AGENTS.md)
- Extracts text, tool calls, token usage, and model info from opencode's response format
- Robust error handling with clear messages when opencode server is unreachable

### Generalized: Claude → LLM/AI naming (17 files)
- **Cost tracker**: `ClaudeUsage` → `LLMUsage`, `recordClaude()` → `recordLLM()`, `costs.claude` → `costs.llm`
- **WebSocket contracts**: `claude_response` → `ai_response`
- **Web client**: `claudeResponse`/`claudeError` → `aiResponse`/`aiError`, UI labels updated
- **Voice context**: Provider-agnostic identity line, `providerHint` type broadened to `string`
- **Voice middleware**: Provider type broadened from `'anthropic' | 'claude-code'` to `string`

### Config (`.env.example`)
- `AI_PROVIDER` now documents `opencode` as a third option
- New `OPENCODE_URL` variable (defaults to `http://127.0.0.1:4096`)

## How to use

```bash
# Start opencode headless (via coda or directly)
coda serve          # or: opencode serve --port 4096

# Configure voice-claude to use it
AI_PROVIDER=opencode
OPENCODE_URL=http://127.0.0.1:4096

# Start voice-claude as usual
pnpm dev
```

## Architecture

```
Phone (earbuds) → Voice Gateway (STT) → opencode headless (multi-provider AI) → Voice Gateway (TTS) → Phone
```

The voice gateway no longer needs to know about AI providers, models, or tool execution. OpenCode (with oh-my-openagent) handles all of that — the voice server is purely a voice I/O bridge.

## Verification
- `pnpm typecheck` ✅ (5/5 tasks pass)
- `pnpm lint` ✅
- Existing providers (`anthropic`, `claude-code`) unmodified and functional