### PR TITLE
feat: openWakeWord wake-word detection service

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -69,6 +69,29 @@ OPENAI_API_KEY=sk-...
 # Conversation history storage (production Docker only, defaults to ./data/conversations)
 # CONVERSATIONS_DIR=./data/conversations
 
+# --- Wake Word Detection (openWakeWord) ---
+
+# Wake word service port (default: 9000)
+# WAKE_WORD_PORT=9000
+
+# Path to custom wake word model file (leave empty to use pre-trained models)
+# WAKE_WORD_MODEL=/models/coda.tflite
+
+# Detection threshold 0-1 (higher = fewer false positives, more missed wakes)
+# WAKE_WORD_THRESHOLD=0.5
+
+# VAD threshold 0-1 (filters non-speech audio before wake detection)
+# WAKE_WORD_VAD_THRESHOLD=0.5
+
+# Consecutive frames above threshold required before triggering (reduces false positives)
+# WAKE_WORD_PATIENCE=3
+
+# Seconds to wait between detections (prevents rapid re-triggering)
+# WAKE_WORD_DEBOUNCE=2.0
+
+# Host directory containing wake word model files
+# WAKE_WORD_MODELS_DIR=./models/wake-word
+
 # --- Self-Hosting / Reverse Proxy ---
 
 # Set to "true" when running behind a reverse proxy (e.g. Traefik, nginx).

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ google-credentials.json
 data/
 models/piper/*.onnx
 models/piper/*.onnx.json
+models/wake-word/*.tflite
+models/wake-word/*.onnx

--- a/OPENWAKEWORD-HANDOFF.md
+++ b/OPENWAKEWORD-HANDOFF.md
@@ -1,0 +1,58 @@
+# openWakeWord follow-up intent
+
+This repo is reserved for the **second phase** of wake-word work after we prove the UX with a Whisper-based keyword prototype in `activate-on-command`.
+
+## Why this exists
+
+The current app's "always listening" mode records too much ambient audio. The immediate plan is to ship a lightweight **Whisper-first wake phrase test** so we can validate the user experience:
+
+1. passive listen
+2. hear `"Coda"`
+3. play a ding
+4. capture the actual request
+5. auto-send after a short silence
+
+Once that flow feels right, this repo becomes the place to build the real wake-word layer with **openWakeWord**.
+
+## Intended outcome for this repo
+
+Build an openWakeWord-based listener that can replace the Whisper wake-phrase prototype with a lower-latency, lower-cost, more reliable passive listening path.
+
+Target behavior:
+
+- microphone can stay open in passive mode
+- passive mode should only do lightweight wake-word detection
+- on detecting `"Coda"`, emit a clear activation event / ding
+- hand off to the existing active-recording pipeline for the spoken request
+- after the request finishes and response playback completes, return to passive mode
+
+## Expected architecture direction
+
+Likely shape:
+
+- **Browser / PWA:** keep mic capture and active recording UX
+- **Wake-word service:** openWakeWord model runner, likely Python-based
+- **Main app/server:** receive wake events and continue handling STT, Codex/Claude processing, and TTS
+
+Most likely deployment options to evaluate:
+
+1. **Docker sidecar** for openWakeWord next to the existing app services
+2. **Bare-metal helper process** on the home Mac for lower friction during testing
+
+## Scope for this repo
+
+- evaluate openWakeWord integration options
+- train or generate a custom `"Coda"` model
+- define the passive-listen → wake → active-record state machine
+- expose a simple interface back to the main app (WebSocket, HTTP, or local IPC)
+- measure false positives, missed wakes, and activation latency
+
+## Out of scope for the first pass here
+
+- reworking the full Codex/Claude request pipeline
+- replacing the current active recording UX
+- solving every mobile browser background-audio limitation up front
+
+## Handoff trigger
+
+Start this effort **after** the Whisper wake-phrase prototype in `activate-on-command` is working well enough to validate the UX and timing.

--- a/apps/server/src/trpc/router.ts
+++ b/apps/server/src/trpc/router.ts
@@ -24,6 +24,13 @@ export const appRouter = createRouter({
         : Number.parseInt(process.env.PORT ?? '4000', 10)
       return { path: '/ws/audio', port }
     }),
+    wakeWord: publicProcedure.query(() => {
+      const behindProxy = process.env.BEHIND_PROXY === 'true'
+      const port = behindProxy
+        ? null
+        : Number.parseInt(process.env.WAKE_WORD_PORT ?? '9000', 10)
+      return { path: '/ws', port, enabled: true }
+    }),
   }),
   stats: publicProcedure.query(() => {
     return getStats()

--- a/apps/web/app/components/mic-button.tsx
+++ b/apps/web/app/components/mic-button.tsx
@@ -1,10 +1,12 @@
 import { PHASE_HINTS } from '../constants/phase-labels.js'
 
+type InputMode = 'push-to-talk' | 'auto' | 'wake-word'
+
 interface MicButtonProps {
   phase: string
   connected: boolean
   busy: boolean
-  mode: 'push-to-talk' | 'auto'
+  mode: InputMode
   onStart: () => void
   onStop: () => void
   onCancel: () => void
@@ -81,6 +83,7 @@ export function MicButton({
   const isRecording = phase === 'recording'
   const isPassiveListening = phase === 'passive-listening'
   const isAuto = mode === 'auto'
+  const isWakeWord = mode === 'wake-word'
   const hints = PHASE_HINTS[mode] ?? PHASE_HINTS['push-to-talk'] ?? {}
 
   const handleClick = () => {
@@ -110,23 +113,26 @@ export function MicButton({
               ? 'bg-red-500/20 border-2 border-red-500 text-red-400 hover:bg-red-500/30'
               : busy
                 ? 'bg-orange-500/10 border-2 border-orange-500/40 text-orange-400 hover:bg-orange-500/20 active:scale-95'
-                : isAuto &&
-                    (phase === 'idle' ||
-                      phase === 'done' ||
-                      phase === 'passive-listening')
-                  ? 'bg-green-500/10 border-2 border-green-500/40 text-green-400 hover:bg-green-500/20'
-                  : 'bg-primary/10 border-2 border-primary/40 text-primary hover:bg-primary/20 hover:border-primary/60 active:scale-95'
+                : isPassiveListening
+                  ? 'bg-emerald-500/10 border-2 border-emerald-500/40 text-emerald-400'
+                  : (isAuto || isWakeWord) &&
+                      (phase === 'idle' || phase === 'done')
+                    ? 'bg-green-500/10 border-2 border-green-500/40 text-green-400 hover:bg-green-500/20'
+                    : 'bg-primary/10 border-2 border-primary/40 text-primary hover:bg-primary/20 hover:border-primary/60 active:scale-95'
           }`}
         >
           {isRecording && (
             <span className="absolute inset-0 rounded-full animate-pulse-ring bg-red-500/20" />
           )}
-          {isAuto && !isRecording && !busy && (
-            <span className="absolute inset-0 rounded-full animate-pulse bg-green-500/5" />
-          )}
           {isPassiveListening && (
-            <span className="absolute inset-0 rounded-full animate-ping bg-green-500/10" />
+            <span className="absolute inset-0 rounded-full animate-pulse bg-emerald-500/10" />
           )}
+          {(isAuto || isWakeWord) &&
+            !isRecording &&
+            !busy &&
+            !isPassiveListening && (
+              <span className="absolute inset-0 rounded-full animate-pulse bg-green-500/5" />
+            )}
           {busy && (
             <span className="absolute inset-0 rounded-full animate-pulse bg-orange-500/10" />
           )}
@@ -144,7 +150,11 @@ export function MicButton({
         onClick={onToggleMode}
         className="text-xs text-muted-foreground/60 hover:text-muted-foreground transition-colors"
       >
-        {isAuto ? 'Switch to tap-to-talk' : 'Switch to auto'}
+        {mode === 'wake-word'
+          ? 'Switch to tap-to-talk'
+          : mode === 'auto'
+            ? 'Switch to wake-word'
+            : 'Switch to auto'}
       </button>
     </div>
   )

--- a/apps/web/app/constants/phase-labels.ts
+++ b/apps/web/app/constants/phase-labels.ts
@@ -22,6 +22,16 @@ export const PHASE_HINTS: Record<string, Record<string, string>> = {
     speaking: 'Tap to stop',
     done: 'Say “Coda”',
   },
+  'wake-word': {
+    idle: 'Connecting to wake-word...',
+    'passive-listening': 'Say "Coda" to activate',
+    recording: 'Speak now...',
+    transcribing: 'Processing...',
+    thinking: 'Tap to cancel',
+    synthesizing: 'Tap to cancel',
+    speaking: 'Tap to stop',
+    done: 'Returning to passive...',
+  },
 }
 
 /**
@@ -32,6 +42,11 @@ export const STATUS_PHASE_CONFIG: Record<
   string,
   { label: string; colorClass: string; showTimer: boolean }
 > = {
+  'passive-listening': {
+    label: 'Listening for "Coda"...',
+    colorClass: 'bg-emerald-500',
+    showTimer: false,
+  },
   recording: {
     label: 'Listening...',
     colorClass: 'bg-red-500',

--- a/apps/web/app/hooks/use-audio-socket.ts
+++ b/apps/web/app/hooks/use-audio-socket.ts
@@ -733,6 +733,10 @@ export function useAudioSocket(wsUrl: string | null) {
     [],
   )
 
+  const setPhase = useCallback((phase: ProcessingPhase) => {
+    setState((s) => ({ ...s, phase }))
+  }, [])
+
   const busy =
     state.phase !== 'idle' &&
     state.phase !== 'done' &&
@@ -754,5 +758,6 @@ export function useAudioSocket(wsUrl: string | null) {
     cancelPlayback,
     micStream,
     sendConversation,
+    setPhase,
   }
 }

--- a/apps/web/app/hooks/use-wake-word.ts
+++ b/apps/web/app/hooks/use-wake-word.ts
@@ -1,0 +1,249 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { createLogger } from '~/lib/logger'
+
+const log = createLogger('wake-word')
+
+interface WakeEvent {
+  model: string
+  score: number
+  timestamp: number
+}
+
+interface WakeWordState {
+  connected: boolean
+  listening: boolean
+  models: string[]
+  lastWake: WakeEvent | null
+}
+
+const RECONNECT_BASE_DELAY = 2000
+const RECONNECT_MAX_DELAY = 30000
+const RECONNECT_MAX_ATTEMPTS = 10
+
+const FRAME_SAMPLES = 2560
+
+export function useWakeWord(wsUrl: string | null, enabled: boolean) {
+  const wsRef = useRef<WebSocket | null>(null)
+  const audioCtxRef = useRef<AudioContext | null>(null)
+  const workletNodeRef = useRef<AudioWorkletNode | null>(null)
+  const streamRef = useRef<MediaStream | null>(null)
+  const reconnectAttemptRef = useRef(0)
+  const reconnectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const intentionalCloseRef = useRef(false)
+  const pausedRef = useRef(false)
+  const onWakeRef = useRef<((event: WakeEvent) => void) | null>(null)
+
+  const [state, setState] = useState<WakeWordState>({
+    connected: false,
+    listening: false,
+    models: [],
+    lastWake: null,
+  })
+
+  const setOnWake = useCallback((cb: ((event: WakeEvent) => void) | null) => {
+    onWakeRef.current = cb
+  }, [])
+
+  const stopAudioPipeline = useCallback(() => {
+    if (workletNodeRef.current) {
+      workletNodeRef.current.port.postMessage('stop')
+      workletNodeRef.current.disconnect()
+      workletNodeRef.current = null
+    }
+    if (streamRef.current) {
+      for (const track of streamRef.current.getTracks()) {
+        track.stop()
+      }
+      streamRef.current = null
+    }
+    if (audioCtxRef.current) {
+      audioCtxRef.current.close()
+      audioCtxRef.current = null
+    }
+  }, [])
+
+  const startAudioPipeline = useCallback(
+    async (ws: WebSocket) => {
+      try {
+        const stream = await navigator.mediaDevices.getUserMedia({
+          audio: {
+            echoCancellation: true,
+            noiseSuppression: true,
+            sampleRate: 16000,
+          },
+        })
+        streamRef.current = stream
+
+        const audioCtx = new AudioContext({ sampleRate: 16000 })
+        audioCtxRef.current = audioCtx
+
+        await audioCtx.audioWorklet.addModule(
+          '/audio-worklet/pcm-capture-processor.js',
+        )
+
+        const source = audioCtx.createMediaStreamSource(stream)
+        const workletNode = new AudioWorkletNode(
+          audioCtx,
+          'pcm-capture-processor',
+          { processorOptions: { frameSamples: FRAME_SAMPLES } },
+        )
+        workletNodeRef.current = workletNode
+
+        workletNode.port.onmessage = (event: MessageEvent<ArrayBuffer>) => {
+          if (ws.readyState === WebSocket.OPEN && !pausedRef.current) {
+            ws.send(event.data)
+          }
+        }
+
+        source.connect(workletNode)
+        workletNode.connect(audioCtx.destination)
+
+        ws.send(JSON.stringify({ sample_rate: audioCtx.sampleRate }))
+
+        setState((s) => ({ ...s, listening: true }))
+        log.info(
+          `streaming PCM at ${audioCtx.sampleRate} Hz, frame=${FRAME_SAMPLES} samples`,
+        )
+      } catch (err) {
+        log.error('failed to start audio pipeline:', err)
+        stopAudioPipeline()
+      }
+    },
+    [stopAudioPipeline],
+  )
+
+  useEffect(() => {
+    if (!wsUrl || !enabled) {
+      if (wsRef.current) {
+        intentionalCloseRef.current = true
+        wsRef.current.close()
+        wsRef.current = null
+      }
+      stopAudioPipeline()
+      setState({
+        connected: false,
+        listening: false,
+        models: [],
+        lastWake: null,
+      })
+      return
+    }
+
+    intentionalCloseRef.current = false
+    const ws = new WebSocket(wsUrl)
+    wsRef.current = ws
+
+    ws.binaryType = 'arraybuffer'
+
+    ws.onopen = () => {
+      log.info('connected to wake-word service')
+      reconnectAttemptRef.current = 0
+      setState((s) => ({ ...s, connected: true }))
+    }
+
+    ws.onmessage = (event) => {
+      if (typeof event.data !== 'string') return
+
+      let msg: Record<string, unknown>
+      try {
+        msg = JSON.parse(event.data)
+      } catch {
+        return
+      }
+
+      if (msg.type === 'ready') {
+        const models = (msg.models as string[]) ?? []
+        log.info('wake-word service ready, models:', models)
+        setState((s) => ({ ...s, models }))
+        startAudioPipeline(ws)
+      }
+
+      if (msg.type === 'wake') {
+        const wakeEvent: WakeEvent = {
+          model: msg.model as string,
+          score: msg.score as number,
+          timestamp: msg.timestamp as number,
+        }
+        log.info(
+          `wake detected: ${wakeEvent.model} (${wakeEvent.score.toFixed(3)})`,
+        )
+        setState((s) => ({ ...s, lastWake: wakeEvent }))
+        onWakeRef.current?.(wakeEvent)
+      }
+    }
+
+    ws.onclose = () => {
+      log.info('disconnected from wake-word service')
+      setState((s) => ({
+        ...s,
+        connected: false,
+        listening: false,
+      }))
+      stopAudioPipeline()
+
+      if (
+        !intentionalCloseRef.current &&
+        reconnectAttemptRef.current < RECONNECT_MAX_ATTEMPTS
+      ) {
+        const attempt = reconnectAttemptRef.current + 1
+        const delay = Math.min(
+          RECONNECT_BASE_DELAY * 2 ** (attempt - 1),
+          RECONNECT_MAX_DELAY,
+        )
+        reconnectAttemptRef.current = attempt
+        log.info(`reconnecting (attempt ${attempt}) in ${delay}ms`)
+        reconnectTimerRef.current = setTimeout(() => {
+          wsRef.current = null
+          setState((s) => ({ ...s, connected: false }))
+        }, delay)
+      }
+    }
+
+    ws.onerror = () => {
+      log.error('wake-word WebSocket error')
+    }
+
+    return () => {
+      intentionalCloseRef.current = true
+      if (reconnectTimerRef.current) {
+        clearTimeout(reconnectTimerRef.current)
+        reconnectTimerRef.current = null
+      }
+      ws.close()
+      stopAudioPipeline()
+    }
+  }, [wsUrl, enabled, startAudioPipeline, stopAudioPipeline])
+
+  const pause = useCallback(() => {
+    pausedRef.current = true
+    const ws = wsRef.current
+    if (ws?.readyState === WebSocket.OPEN) {
+      ws.send(JSON.stringify({ type: 'pause' }))
+    }
+    if (workletNodeRef.current) {
+      workletNodeRef.current.port.postMessage('stop')
+    }
+    setState((s) => ({ ...s, listening: false }))
+    log.debug('paused')
+  }, [])
+
+  const resume = useCallback(() => {
+    pausedRef.current = false
+    const ws = wsRef.current
+    if (ws?.readyState === WebSocket.OPEN) {
+      ws.send(JSON.stringify({ type: 'resume' }))
+    }
+    if (workletNodeRef.current) {
+      workletNodeRef.current.port.postMessage('start')
+    }
+    setState((s) => ({ ...s, listening: true }))
+    log.debug('resumed')
+  }, [])
+
+  return {
+    ...state,
+    pause,
+    resume,
+    setOnWake,
+  }
+}

--- a/apps/web/app/root.tsx
+++ b/apps/web/app/root.tsx
@@ -13,12 +13,13 @@ import { createServerTRPC } from './trpc/server.js'
 export async function loader({ context }: Route.LoaderArgs) {
   const ctx = context as { cookie?: string }
   const trpc = createServerTRPC(ctx.cookie ?? '')
-  const [health, wsConfig] = await Promise.all([
+  const [health, wsConfig, wakeWordConfig] = await Promise.all([
     trpc.health.check.query().catch(() => null),
     trpc.config.wsUrl.query().catch(() => null),
+    trpc.config.wakeWord.query().catch(() => null),
   ])
 
-  return { health, wsConfig }
+  return { health, wsConfig, wakeWordConfig }
 }
 
 export function Layout({ children }: { children: React.ReactNode }) {

--- a/apps/web/app/routes/home.tsx
+++ b/apps/web/app/routes/home.tsx
@@ -12,11 +12,19 @@ import { StatusIndicator } from '../components/status-indicator.js'
 import { useAudioSocket } from '../hooks/use-audio-socket.js'
 import { useSoundEffects } from '../hooks/use-sound-effects.js'
 import { useVAD } from '../hooks/use-vad.js'
+import { useWakeWord } from '../hooks/use-wake-word.js'
 import { getClientTRPC } from '../trpc/client.js'
+
+type InputMode = 'push-to-talk' | 'auto' | 'wake-word'
 
 interface RootContext {
   health: { status: string; timestamp: string } | null
   wsConfig: { path: string; port: number | null } | null
+  wakeWordConfig?: {
+    path: string
+    port: number | null
+    enabled: boolean
+  } | null
 }
 
 interface ConversationEntry {
@@ -39,7 +47,7 @@ export function meta() {
 }
 
 export default function Home() {
-  const { health, wsConfig } = useOutletContext<RootContext>()
+  const { health, wsConfig, wakeWordConfig } = useOutletContext<RootContext>()
 
   const wsUrl = useMemo(() => {
     if (typeof window === 'undefined' || !wsConfig) return null
@@ -54,6 +62,16 @@ export default function Home() {
     return `${protocol}//${host}${wsConfig.path}`
   }, [wsConfig])
 
+  const wakeWordWsUrl = useMemo(() => {
+    if (typeof window === 'undefined' || !wakeWordConfig?.enabled) return null
+    const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:'
+    const host =
+      wakeWordConfig.port != null
+        ? `${window.location.hostname}:${wakeWordConfig.port}`
+        : window.location.host
+    return `${protocol}//${host}${wakeWordConfig.path}`
+  }, [wakeWordConfig])
+
   const trpc = typeof window === 'undefined' ? null : getClientTRPC()
 
   const audio = useAudioSocket(wsUrl)
@@ -61,23 +79,54 @@ export default function Home() {
   const phaseRef = useRef(audio.phase)
   const spaceDownRef = useRef(false)
 
-  // Mode: push-to-talk (default) or auto (always-listening with VAD)
-  const [mode, setMode] = useState<'push-to-talk' | 'auto'>('push-to-talk')
+  const [mode, setMode] = useState<InputMode>('push-to-talk')
+  const isWakeWordMode = mode === 'wake-word'
+
+  const wakeWord = useWakeWord(wakeWordWsUrl, isWakeWordMode)
+
   const toggleMode = useCallback(() => {
     setMode((m) => {
-      if (m === 'auto') {
-        // Switching to push-to-talk: cancel any in-progress recording without sending
-        if (audio.phase === 'recording') {
-          audio.cancelRecording()
-        }
-        if (audio.phase === 'passive-listening') {
-          audio.stopPassiveListening()
-        }
-        return 'push-to-talk'
+      if (m === 'push-to-talk') return 'auto'
+      if (m === 'auto') return wakeWordWsUrl ? 'wake-word' : 'push-to-talk'
+      if (audio.phase === 'recording') {
+        audio.cancelRecording()
       }
-      return 'auto'
+      if (audio.phase === 'passive-listening') {
+        audio.stopPassiveListening?.()
+      }
+      return 'push-to-talk'
     })
-  }, [audio])
+  }, [audio, wakeWordWsUrl])
+
+  // Wake-word mode: set passive-listening phase and handle wake events
+  useEffect(() => {
+    if (!isWakeWordMode) return
+
+    if (wakeWord.listening && audio.phase === 'idle') {
+      audio.setPhase('passive-listening')
+    }
+
+    wakeWord.setOnWake(() => {
+      log.info('wake word detected, starting active recording')
+      play('commandAcknowledged')
+      wakeWord.pause()
+      audio.startRecording()
+    })
+
+    return () => wakeWord.setOnWake(null)
+  }, [isWakeWordMode, wakeWord, audio, play])
+
+  // Wake-word mode: return to passive listening after response completes
+  useEffect(() => {
+    if (!isWakeWordMode) return
+    if (audio.phase === 'done') {
+      const timer = setTimeout(() => {
+        wakeWord.resume()
+        audio.setPhase('passive-listening')
+      }, 500)
+      return () => clearTimeout(timer)
+    }
+  }, [isWakeWordMode, audio.phase, wakeWord, audio.setPhase])
 
   // VAD for auto mode
   const vad = useVAD(
@@ -447,6 +496,7 @@ export default function Home() {
   }, [audio, handleStartRecording])
 
   const showStatus =
+    audio.phase === 'passive-listening' ||
     audio.phase === 'recording' ||
     audio.phase === 'transcribing' ||
     audio.phase === 'thinking' ||

--- a/apps/web/public/audio-worklet/pcm-capture-processor.js
+++ b/apps/web/public/audio-worklet/pcm-capture-processor.js
@@ -1,0 +1,65 @@
+/**
+ * AudioWorklet processor that captures raw PCM audio and sends it to the main
+ * thread in 16-bit integer format. Buffers samples to the configured frame size
+ * before posting to reduce WebSocket message frequency.
+ *
+ * Register: audioContext.audioWorklet.addModule('/audio-worklet/pcm-capture-processor.js')
+ * Create:   new AudioWorkletNode(ctx, 'pcm-capture-processor', { processorOptions: { frameSamples: 2560 } })
+ */
+class PCMCaptureProcessor extends AudioWorkletProcessor {
+  constructor(options) {
+    super()
+    this._frameSamples = options?.processorOptions?.frameSamples ?? 2560
+    this._buffer = new Float32Array(this._frameSamples)
+    this._writeIndex = 0
+    this._active = true
+
+    this.port.onmessage = (event) => {
+      if (event.data === 'stop') {
+        this._active = false
+      } else if (event.data === 'start') {
+        this._active = true
+        this._writeIndex = 0
+      }
+    }
+  }
+
+  process(inputs) {
+    if (!this._active) return true
+
+    const input = inputs[0]
+    if (!input || !input[0]) return true
+
+    const channel = input[0]
+    let readIndex = 0
+
+    while (readIndex < channel.length) {
+      const remaining = this._frameSamples - this._writeIndex
+      const available = channel.length - readIndex
+      const toCopy = Math.min(remaining, available)
+
+      this._buffer.set(
+        channel.subarray(readIndex, readIndex + toCopy),
+        this._writeIndex,
+      )
+      this._writeIndex += toCopy
+      readIndex += toCopy
+
+      if (this._writeIndex >= this._frameSamples) {
+        const int16 = new Int16Array(this._frameSamples)
+        for (let i = 0; i < this._frameSamples; i++) {
+          const s = Math.max(-1, Math.min(1, this._buffer[i]))
+          int16[i] = s < 0 ? s * 0x8000 : s * 0x7fff
+        }
+        this.port.postMessage(int16.buffer, [int16.buffer])
+
+        this._buffer = new Float32Array(this._frameSamples)
+        this._writeIndex = 0
+      }
+    }
+
+    return true
+  }
+}
+
+registerProcessor('pcm-capture-processor', PCMCaptureProcessor)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,6 +44,19 @@ services:
     depends_on:
       - server
 
+  wake-word:
+    build:
+      context: ./services/wake-word
+    ports:
+      - "${WAKE_WORD_PORT:-9000}:9000"
+    env_file:
+      - .env
+    environment:
+      WAKE_WORD_PORT: "9000"
+      WAKE_WORD_MODEL: "${WAKE_WORD_MODEL:-}"
+    volumes:
+      - ${WAKE_WORD_MODELS_DIR:-./models/wake-word}:/models
+
   piper:
     build:
       context: ./docker/piper

--- a/services/wake-word/Dockerfile
+++ b/services/wake-word/Dockerfile
@@ -1,0 +1,21 @@
+FROM python:3.11-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libspeexdsp-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY wake_word_service.py .
+
+ENV WAKE_WORD_PORT=9000
+
+EXPOSE 9000
+
+HEALTHCHECK --interval=10s --timeout=3s --start-period=30s \
+  CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:9000/health')" || exit 1
+
+CMD ["python", "wake_word_service.py"]

--- a/services/wake-word/requirements.txt
+++ b/services/wake-word/requirements.txt
@@ -1,0 +1,4 @@
+openwakeword>=0.6.0,<1.0
+aiohttp>=3.9.0,<4.0
+numpy>=1.20.0,<2.0
+resampy>=0.4.0,<1.0

--- a/services/wake-word/training/coda_model.yml
+++ b/services/wake-word/training/coda_model.yml
@@ -1,0 +1,19 @@
+model_name: "coda"
+target_phrase:
+  - "coda"
+  - "hey coda"
+  - "ok coda"
+
+n_samples: 10000
+n_samples_val: 2000
+
+tts_batch_size: 50
+augmentation_batch_size: 16
+augmentation_rounds: 1
+
+model_type: "dnn"
+layer_size: 32
+
+steps: 50000
+max_negative_weight: 1500
+target_false_positives_per_hour: 0.2

--- a/services/wake-word/training/generate_clips.py
+++ b/services/wake-word/training/generate_clips.py
@@ -1,0 +1,113 @@
+"""Generate synthetic TTS clips for openWakeWord training using Microsoft Edge TTS.
+
+Replaces piper-sample-generator (which depends on the archived piper-phonemize
+and doesn't support Python 3.12 on Linux).
+
+Usage:
+  pip install edge-tts pydub
+  python generate_clips.py --phrase "coda" --count 1500 --output ./my_custom_model
+
+Output: WAV files at 16kHz mono in <output>/positive_clips/ — ready for
+openWakeWord's --augment_clips step.
+"""
+
+import argparse
+import asyncio
+import random
+import struct
+import sys
+import wave
+from pathlib import Path
+
+PHRASE_VARIATIONS = {
+    "coda": ["coda", "Coda", "CODA", "coda!", "coda."],
+    "hey coda": ["hey coda", "Hey Coda", "hey, coda", "Hey, Coda"],
+}
+
+RATE_VARIATIONS = ["-20%", "-10%", "+0%", "+10%", "+20%"]
+PITCH_VARIATIONS = ["-5Hz", "+0Hz", "+5Hz", "+10Hz"]
+
+
+async def get_english_voices():
+    import edge_tts
+
+    voices = await edge_tts.list_voices()
+    return [v for v in voices if v["Locale"].startswith("en-")]
+
+
+async def generate_one_clip(text, voice_name, rate, pitch, output_path):
+    import edge_tts
+
+    communicate = edge_tts.Communicate(text, voice_name, rate=rate, pitch=pitch)
+    await communicate.save(str(output_path))
+
+
+def mp3_to_wav16k(mp3_path, wav_path):
+    from pydub import AudioSegment
+
+    audio = AudioSegment.from_mp3(str(mp3_path))
+    audio = audio.set_frame_rate(16000).set_channels(1).set_sample_width(2)
+    audio.export(str(wav_path), format="wav")
+
+
+async def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--phrase", default="coda")
+    parser.add_argument("--count", type=int, default=1500)
+    parser.add_argument("--output", default="./my_custom_model")
+    parser.add_argument("--val-count", type=int, default=500)
+    args = parser.parse_args()
+
+    output_dir = Path(args.output) / "positive_clips"
+    output_dir.mkdir(parents=True, exist_ok=True)
+    val_dir = Path(args.output) / "positive_clips_val"
+    val_dir.mkdir(parents=True, exist_ok=True)
+    tmp_dir = Path(args.output) / "_tmp_mp3"
+    tmp_dir.mkdir(parents=True, exist_ok=True)
+
+    variations = PHRASE_VARIATIONS.get(args.phrase, [args.phrase])
+
+    print("Fetching voice list...")
+    voices = await get_english_voices()
+    print(f"Found {len(voices)} English voices")
+
+    total = args.count + args.val_count
+    generated = 0
+    errors = 0
+
+    for i in range(total):
+        voice = random.choice(voices)
+        text = random.choice(variations)
+        rate = random.choice(RATE_VARIATIONS)
+        pitch = random.choice(PITCH_VARIATIONS)
+
+        is_val = i >= args.count
+        dest_dir = val_dir if is_val else output_dir
+        mp3_path = tmp_dir / f"clip_{i:05d}.mp3"
+        wav_path = dest_dir / f"clip_{i:05d}.wav"
+
+        try:
+            await generate_one_clip(text, voice["Name"], rate, pitch, mp3_path)
+            mp3_to_wav16k(mp3_path, wav_path)
+            mp3_path.unlink()
+            generated += 1
+        except Exception as e:
+            errors += 1
+            if errors < 5:
+                print(f"  error with {voice['Name']}: {e}")
+            continue
+
+        if (i + 1) % 50 == 0:
+            split = "val" if is_val else "train"
+            print(f"  [{split}] {generated}/{total} clips generated ({errors} errors)")
+
+    print(f"\nDone: {generated} clips in {output_dir} and {val_dir}")
+    print(f"Errors: {errors}")
+
+    import shutil
+
+    shutil.rmtree(tmp_dir, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/services/wake-word/training/train_coda_model.ipynb
+++ b/services/wake-word/training/train_coda_model.ipynb
@@ -1,0 +1,395 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Train a Custom \"Coda\" Wake Word Model\n",
+    "\n",
+    "This notebook trains an openWakeWord model for the wake word **\"Coda\"**.\n",
+    "\n",
+    "It replaces the original Colab notebook's broken piper-phonemize dependency with **edge-tts** (Microsoft Edge TTS) for synthetic clip generation.\n",
+    "\n",
+    "**Steps:**\n",
+    "1. Install dependencies\n",
+    "2. Download training data (background noise, negative features)\n",
+    "3. Generate synthetic \"coda\" clips with edge-tts\n",
+    "4. Augment clips with noise and reverb\n",
+    "5. Train the model\n",
+    "6. Download the trained model\n",
+    "\n",
+    "**Time:** ~1 hour for clip generation, ~30 min augmentation, ~2-4 hours training.\n",
+    "\n",
+    "**Requirements:** Free Google Colab account. No GPU needed for clip generation, but training is faster with one.\n",
+    "\n",
+    "Go to **Runtime > Change runtime type > T4 GPU** before starting."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 1: Install Dependencies"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!git clone https://github.com/dscripka/openwakeword\n",
+    "!pip install -e ./openwakeword\n",
+    "\n",
+    "!pip install edge-tts pydub nest_asyncio\n",
+    "!pip install mutagen==1.47.0 torchinfo==1.8.0 torchmetrics==1.2.0\n",
+    "!pip install speechbrain==0.5.14\n",
+    "!pip install audiomentations==0.33.0 torch-audiomentations==0.11.0\n",
+    "!pip install acoustics==0.2.6 pronouncing==0.2.0\n",
+    "!pip install datasets==2.14.6 deep-phonemizer==0.0.19\n",
+    "\n",
+    "import os\n",
+    "os.makedirs(\"./openwakeword/openwakeword/resources/models\", exist_ok=True)\n",
+    "!wget -q https://github.com/dscripka/openWakeWord/releases/download/v0.5.1/embedding_model.onnx -O ./openwakeword/openwakeword/resources/models/embedding_model.onnx\n",
+    "!wget -q https://github.com/dscripka/openWakeWord/releases/download/v0.5.1/embedding_model.tflite -O ./openwakeword/openwakeword/resources/models/embedding_model.tflite\n",
+    "!wget -q https://github.com/dscripka/openWakeWord/releases/download/v0.5.1/melspectrogram.onnx -O ./openwakeword/openwakeword/resources/models/melspectrogram.onnx\n",
+    "!wget -q https://github.com/dscripka/openWakeWord/releases/download/v0.5.1/melspectrogram.tflite -O ./openwakeword/openwakeword/resources/models/melspectrogram.tflite\n",
+    "\n",
+    "# Patch torchaudio if needed (Colab ships torchaudio 2.10+ which removed set_audio_backend)\n",
+    "import torchaudio\n",
+    "if not hasattr(torchaudio, 'set_audio_backend'):\n",
+    "    torchaudio.set_audio_backend = lambda x: None\n",
+    "\n",
+    "print(\"\\n=== Setup complete ===\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 2: Download Training Data\n",
+    "\n",
+    "This downloads:\n",
+    "- Room impulse responses (for reverb augmentation)\n",
+    "- Background noise and music (AudioSet + FMA)\n",
+    "- Pre-computed negative features (2000 hrs of non-wake-word audio)\n",
+    "\n",
+    "Takes ~15-20 minutes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import numpy as np\n",
+    "import scipy\n",
+    "import datasets\n",
+    "from pathlib import Path\n",
+    "from tqdm import tqdm\n",
+    "\n",
+    "# Room impulse responses\n",
+    "output_dir = \"./mit_rirs\"\n",
+    "if not os.path.exists(output_dir):\n",
+    "    os.mkdir(output_dir)\n",
+    "    rir_dataset = datasets.load_dataset(\"davidscripka/MIT_environmental_impulse_responses\", split=\"train\", streaming=True)\n",
+    "    for row in tqdm(rir_dataset, desc=\"Room impulse responses\"):\n",
+    "        name = row['audio']['path'].split('/')[-1]\n",
+    "        scipy.io.wavfile.write(os.path.join(output_dir, name), 16000, (row['audio']['array']*32767).astype(np.int16))\n",
+    "    print(f\"Saved RIRs to {output_dir}\")\n",
+    "else:\n",
+    "    print(f\"RIRs already exist at {output_dir}, skipping\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Background noise: AudioSet + Free Music Archive\n",
+    "\n",
+    "if not os.path.exists(\"audioset\"):\n",
+    "    os.mkdir(\"audioset\")\n",
+    "fname = \"bal_train09.tar\"\n",
+    "out = f\"audioset/{fname}\"\n",
+    "link = \"https://huggingface.co/datasets/agkphysics/AudioSet/resolve/main/data/\" + fname\n",
+    "if not os.path.exists(out):\n",
+    "    !wget -q -O {out} {link}\n",
+    "    !cd audioset && tar -xf {fname}\n",
+    "\n",
+    "output_dir = \"./audioset_16k\"\n",
+    "if not os.path.exists(output_dir):\n",
+    "    os.mkdir(output_dir)\n",
+    "    audioset_dataset = datasets.Dataset.from_dict({\"audio\": [str(i) for i in Path(\"audioset/audio\").glob(\"**/*.flac\")]})\n",
+    "    audioset_dataset = audioset_dataset.cast_column(\"audio\", datasets.Audio(sampling_rate=16000))\n",
+    "    for row in tqdm(audioset_dataset, desc=\"AudioSet\"):\n",
+    "        name = row['audio']['path'].split('/')[-1].replace(\".flac\", \".wav\")\n",
+    "        scipy.io.wavfile.write(os.path.join(output_dir, name), 16000, (row['audio']['array']*32767).astype(np.int16))\n",
+    "\n",
+    "output_dir = \"./fma\"\n",
+    "if not os.path.exists(output_dir):\n",
+    "    os.mkdir(output_dir)\n",
+    "    fma_dataset = datasets.load_dataset(\"rudraml/fma\", name=\"small\", split=\"train\", streaming=True)\n",
+    "    fma_dataset = iter(fma_dataset.cast_column(\"audio\", datasets.Audio(sampling_rate=16000)))\n",
+    "    for i in tqdm(range(120), desc=\"FMA music\"):\n",
+    "        row = next(fma_dataset)\n",
+    "        name = row['audio']['path'].split('/')[-1].replace(\".mp3\", \".wav\")\n",
+    "        scipy.io.wavfile.write(os.path.join(output_dir, name), 16000, (row['audio']['array']*32767).astype(np.int16))\n",
+    "\n",
+    "print(\"Background audio ready\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Pre-computed negative features (~2GB download)\n",
+    "if not os.path.exists(\"openwakeword_features_ACAV100M_2000_hrs_16bit.npy\"):\n",
+    "    !wget -q https://huggingface.co/datasets/davidscripka/openwakeword_features/resolve/main/openwakeword_features_ACAV100M_2000_hrs_16bit.npy\n",
+    "    print(\"Downloaded training features\")\n",
+    "\n",
+    "if not os.path.exists(\"validation_set_features.npy\"):\n",
+    "    !wget -q https://huggingface.co/datasets/davidscripka/openwakeword_features/resolve/main/validation_set_features.npy\n",
+    "    print(\"Downloaded validation features\")\n",
+    "\n",
+    "print(\"All data ready\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 3: Generate Synthetic \"Coda\" Clips with Edge TTS\n",
+    "\n",
+    "This replaces the broken piper-sample-generator step.\n",
+    "\n",
+    "Uses Microsoft Edge's free TTS service with 300+ English voices at varied speeds and pitches to create diverse training clips.\n",
+    "\n",
+    "Takes ~30-60 minutes for 1500 clips."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import asyncio\n",
+    "import random\n",
+    "import shutil\n",
+    "from pathlib import Path\n",
+    "from pydub import AudioSegment\n",
+    "import edge_tts\n",
+    "import nest_asyncio\n",
+    "nest_asyncio.apply()\n",
+    "\n",
+    "PHRASE = \"coda\"\n",
+    "N_TRAIN = 1500\n",
+    "N_VAL = 500\n",
+    "TOTAL = N_TRAIN + N_VAL\n",
+    "\n",
+    "VARIATIONS = [\"coda\", \"Coda\", \"CODA\", \"coda.\", \"Coda!\"]\n",
+    "RATES = [\"-30%\", \"-20%\", \"-10%\", \"+0%\", \"+10%\", \"+20%\", \"+30%\"]\n",
+    "PITCHES = [\"-10Hz\", \"-5Hz\", \"+0Hz\", \"+5Hz\", \"+10Hz\"]\n",
+    "\n",
+    "out_train = Path(\"my_custom_model/positive_clips\")\n",
+    "out_val = Path(\"my_custom_model/positive_clips_val\")\n",
+    "tmp = Path(\"my_custom_model/_tmp\")\n",
+    "for d in [out_train, out_val, tmp]:\n",
+    "    d.mkdir(parents=True, exist_ok=True)\n",
+    "\n",
+    "voices = [v for v in asyncio.run(edge_tts.list_voices()) if v[\"Locale\"].startswith(\"en-\")]\n",
+    "print(f\"{len(voices)} English voices available\")\n",
+    "\n",
+    "async def generate_clip(text, voice, rate, pitch, path):\n",
+    "    c = edge_tts.Communicate(text, voice, rate=rate, pitch=pitch)\n",
+    "    await c.save(str(path))\n",
+    "\n",
+    "generated = 0\n",
+    "errors = 0\n",
+    "\n",
+    "for i in range(TOTAL):\n",
+    "    v = random.choice(voices)\n",
+    "    mp3 = tmp / f\"{i:05d}.mp3\"\n",
+    "    dest = out_val if i >= N_TRAIN else out_train\n",
+    "    wav = dest / f\"{i:05d}.wav\"\n",
+    "    try:\n",
+    "        asyncio.run(generate_clip(\n",
+    "            random.choice(VARIATIONS),\n",
+    "            v[\"Name\"],\n",
+    "            random.choice(RATES),\n",
+    "            random.choice(PITCHES),\n",
+    "            mp3\n",
+    "        ))\n",
+    "        audio = AudioSegment.from_mp3(str(mp3))\n",
+    "        audio = audio.set_frame_rate(16000).set_channels(1).set_sample_width(2)\n",
+    "        audio.export(str(wav), format=\"wav\")\n",
+    "        mp3.unlink()\n",
+    "        generated += 1\n",
+    "    except Exception as e:\n",
+    "        errors += 1\n",
+    "        if errors <= 3:\n",
+    "            print(f\"  skip {v['Name']}: {e}\")\n",
+    "        continue\n",
+    "\n",
+    "    if (i + 1) % 100 == 0:\n",
+    "        label = \"val\" if i >= N_TRAIN else \"train\"\n",
+    "        print(f\"  [{label}] {i+1}/{TOTAL} done\")\n",
+    "\n",
+    "shutil.rmtree(tmp, ignore_errors=True)\n",
+    "n_train = len(list(out_train.glob(\"*.wav\")))\n",
+    "n_val = len(list(out_val.glob(\"*.wav\")))\n",
+    "print(f\"\\nDone: {n_train} train clips, {n_val} val clips, {errors} errors\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 4: Configure Training"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import yaml\n",
+    "\n",
+    "config = yaml.load(open(\"openwakeword/examples/custom_model.yml\", 'r').read(), yaml.Loader)\n",
+    "\n",
+    "config[\"target_phrase\"] = [\"coda\"]\n",
+    "config[\"model_name\"] = \"coda\"\n",
+    "config[\"n_samples\"] = len(list(Path(\"my_custom_model/positive_clips\").glob(\"*.wav\")))\n",
+    "config[\"n_samples_val\"] = len(list(Path(\"my_custom_model/positive_clips_val\").glob(\"*.wav\")))\n",
+    "config[\"steps\"] = 10000\n",
+    "config[\"target_accuracy\"] = 0.6\n",
+    "config[\"target_recall\"] = 0.25\n",
+    "\n",
+    "config[\"background_paths\"] = ['./audioset_16k', './fma']\n",
+    "config[\"false_positive_validation_data_path\"] = \"validation_set_features.npy\"\n",
+    "config[\"feature_data_files\"] = {\"ACAV100M_sample\": \"openwakeword_features_ACAV100M_2000_hrs_16bit.npy\"}\n",
+    "\n",
+    "with open('my_model.yaml', 'w') as f:\n",
+    "    yaml.dump(config, f)\n",
+    "\n",
+    "print(f\"Config saved. Training {config['n_samples']} clips for {config['steps']} steps.\")\n",
+    "print(f\"Phrase: {config['target_phrase']}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 5: Augment Clips\n",
+    "\n",
+    "Mixes the synthetic clips with background noise, reverb, and volume changes.\n",
+    "\n",
+    "Takes ~5-15 minutes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys\n",
+    "\n",
+    "# Ensure torchaudio patch is active\n",
+    "import torchaudio\n",
+    "if not hasattr(torchaudio, 'set_audio_backend'):\n",
+    "    torchaudio.set_audio_backend = lambda x: None\n",
+    "\n",
+    "!{sys.executable} openwakeword/openwakeword/train.py --training_config my_model.yaml --augment_clips"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 6: Train the Model\n",
+    "\n",
+    "Trains a small DNN on top of the openWakeWord embedding model.\n",
+    "\n",
+    "Takes ~2-4 hours on a T4 GPU, longer on CPU."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys\n",
+    "\n",
+    "!{sys.executable} openwakeword/openwakeword/train.py --training_config my_model.yaml --train_model"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 7: Download Your Model\n",
+    "\n",
+    "The trained model is saved as `my_custom_model/coda.onnx`.\n",
+    "\n",
+    "Download it and place it in `models/wake-word/coda.onnx` in your voice-claude project, then set `WAKE_WORD_MODEL=/models/coda.onnx` in your `.env` file."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "\n",
+    "onnx_path = Path(\"my_custom_model/coda.onnx\")\n",
+    "tflite_path = Path(\"my_custom_model/coda.tflite\")\n",
+    "\n",
+    "if onnx_path.exists():\n",
+    "    size = onnx_path.stat().st_size / 1024\n",
+    "    print(f\"Model ready: {onnx_path} ({size:.0f} KB)\")\n",
+    "    print(\"Right-click the file in the left sidebar > Download\")\n",
+    "else:\n",
+    "    print(\"ERROR: Model not found. Check the training output above for errors.\")\n",
+    "\n",
+    "if tflite_path.exists():\n",
+    "    print(f\"TFLite version also available: {tflite_path}\")\n",
+    "else:\n",
+    "    print(\"TFLite conversion not available (expected on Python 3.12). Use the .onnx file instead.\")\n",
+    "\n",
+    "# Quick test\n",
+    "try:\n",
+    "    from openwakeword.model import Model\n",
+    "    model = Model(wakeword_models=[str(onnx_path)])\n",
+    "    print(f\"\\nModel loads successfully. Detected models: {list(model.models.keys())}\")\n",
+    "except Exception as e:\n",
+    "    print(f\"Model load test failed: {e}\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "colab": {
+   "provenance": []
+  },
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.12.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/services/wake-word/wake_word_service.py
+++ b/services/wake-word/wake_word_service.py
@@ -1,0 +1,217 @@
+"""openWakeWord WebSocket service for real-time wake-word detection.
+
+Protocol:
+  Client -> Server:
+    1. First text message: JSON {"sample_rate": 16000} (optional, defaults to 16000)
+    2. Binary messages: raw 16-bit PCM audio frames
+
+  Server -> Client:
+    1. On connect: JSON {"type": "ready", "models": ["coda"], "sample_rate": 16000}
+    2. On wake detection: JSON {"type": "wake", "model": "coda", "score": 0.87, "timestamp": ...}
+"""
+
+import json
+import logging
+import os
+import sys
+import time
+
+import numpy as np
+from aiohttp import WSMsgType, web
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="[wake-word] %(levelname)s %(message)s",
+    stream=sys.stdout,
+)
+log = logging.getLogger("wake-word")
+
+from dataclasses import dataclass, field
+
+PORT = int(os.environ.get("WAKE_WORD_PORT", "9000"))
+MODEL_PATH = os.environ.get("WAKE_WORD_MODEL", "")
+THRESHOLD = float(os.environ.get("WAKE_WORD_THRESHOLD", "0.5"))
+VAD_THRESHOLD = float(os.environ.get("WAKE_WORD_VAD_THRESHOLD", "0.5"))
+PATIENCE = int(os.environ.get("WAKE_WORD_PATIENCE", "3"))
+DEBOUNCE_SEC = float(os.environ.get("WAKE_WORD_DEBOUNCE", "2.0"))
+ENABLE_SPEEX = os.environ.get("WAKE_WORD_SPEEX", "false").lower() == "true"
+EXPECTED_SAMPLE_RATE = 16000
+
+
+@dataclass
+class Metrics:
+    total_detections: int = 0
+    total_audio_frames: int = 0
+    total_audio_seconds: float = 0.0
+    start_time: float = field(default_factory=time.time)
+    detection_timestamps: list = field(default_factory=list)
+
+    def record_detection(self, model: str, score: float):
+        self.total_detections += 1
+        self.detection_timestamps.append(
+            {"model": model, "score": score, "time": time.time()}
+        )
+
+    def record_audio(self, samples: int):
+        self.total_audio_frames += 1
+        self.total_audio_seconds += samples / EXPECTED_SAMPLE_RATE
+
+    def to_dict(self):
+        uptime = time.time() - self.start_time
+        detections_per_hour = (
+            (self.total_detections / uptime * 3600) if uptime > 0 else 0
+        )
+        return {
+            "uptime_seconds": round(uptime, 1),
+            "total_detections": self.total_detections,
+            "detections_per_hour": round(detections_per_hour, 3),
+            "total_audio_frames": self.total_audio_frames,
+            "total_audio_seconds": round(self.total_audio_seconds, 1),
+            "recent_detections": self.detection_timestamps[-20:],
+        }
+
+
+metrics = Metrics()
+
+
+def load_model():
+    import openwakeword
+
+    model_kwargs = {
+        "vad_threshold": VAD_THRESHOLD,
+    }
+
+    if ENABLE_SPEEX:
+        model_kwargs["enable_speex_noise_suppression"] = True
+
+    if MODEL_PATH:
+        model_kwargs["wakeword_models"] = [MODEL_PATH]
+        log.info("loading custom model: %s", MODEL_PATH)
+    else:
+        log.info("no custom model specified, downloading pre-trained models...")
+        openwakeword.utils.download_models()
+
+    from openwakeword.model import Model
+
+    model = Model(**model_kwargs)
+    log.info("loaded models: %s", list(model.models.keys()))
+    return model
+
+
+# ── Handlers ─────────────────────────────────────────────────────
+
+
+async def health_handler(request):
+    return web.json_response({"status": "ok", "port": PORT})
+
+
+async def metrics_handler(request):
+    return web.json_response(metrics.to_dict())
+
+
+async def websocket_handler(request):
+    ws = web.WebSocketResponse()
+    await ws.prepare(request)
+
+    client = request.remote or "unknown"
+    log.info("client connected: %s", client)
+
+    model = request.app["model"]
+    model_names = list(model.models.keys())
+    sample_rate = EXPECTED_SAMPLE_RATE
+    resampler = None
+
+    await ws.send_json(
+        {
+            "type": "ready",
+            "models": model_names,
+            "sample_rate": EXPECTED_SAMPLE_RATE,
+            "threshold": THRESHOLD,
+        }
+    )
+
+    try:
+        async for msg in ws:
+            if msg.type == WSMsgType.TEXT:
+                try:
+                    config = json.loads(msg.data)
+                except json.JSONDecodeError:
+                    continue
+
+                if "sample_rate" in config:
+                    sample_rate = int(config["sample_rate"])
+                    log.info("client sample rate: %d Hz", sample_rate)
+                    if sample_rate != EXPECTED_SAMPLE_RATE:
+                        import resampy
+
+                        resampler = lambda data: resampy.resample(
+                            data.astype(np.float32),
+                            sample_rate,
+                            EXPECTED_SAMPLE_RATE,
+                        ).astype(np.int16)
+                    else:
+                        resampler = None
+
+                msg_type = config.get("type")
+                if msg_type == "resume":
+                    model.reset()
+                    log.debug("model state reset on resume")
+
+            elif msg.type == WSMsgType.BINARY:
+                audio_data = np.frombuffer(msg.data, dtype=np.int16)
+                if len(audio_data) == 0:
+                    continue
+
+                metrics.record_audio(len(audio_data))
+
+                if resampler is not None:
+                    audio_data = resampler(audio_data)
+
+                predictions = model.predict(
+                    audio_data,
+                    patience={name: PATIENCE for name in model_names},
+                    threshold={name: THRESHOLD for name in model_names},
+                    debounce_time=DEBOUNCE_SEC,
+                )
+
+                for name, score in predictions.items():
+                    if score >= THRESHOLD:
+                        metrics.record_detection(name, float(score))
+                        log.info("WAKE DETECTED: model=%s score=%.4f", name, score)
+                        await ws.send_json(
+                            {
+                                "type": "wake",
+                                "model": name,
+                                "score": round(float(score), 4),
+                                "timestamp": int(time.time() * 1000),
+                            }
+                        )
+
+            elif msg.type in (WSMsgType.ERROR, WSMsgType.CLOSE):
+                break
+
+    except Exception:
+        log.exception("error in WebSocket handler")
+    finally:
+        log.info("client disconnected: %s", client)
+
+    return ws
+
+
+# ── App ──────────────────────────────────────────────────────────
+
+
+def create_app():
+    app = web.Application()
+    log.info("initializing openWakeWord...")
+    app["model"] = load_model()
+    app.router.add_get("/health", health_handler)
+    app.router.add_get("/metrics", metrics_handler)
+    app.router.add_get("/ws", websocket_handler)
+    return app
+
+
+if __name__ == "__main__":
+    app = create_app()
+    log.info("starting on port %d", PORT)
+    web.run_app(app, host="0.0.0.0", port=PORT, print=None)


### PR DESCRIPTION
## Summary

Replaces the Whisper-based wake phrase prototype (`activate-on-command`) with a dedicated **openWakeWord** service for lower-latency, lower-cost passive wake word detection.

- **Python wake-word service** (`services/wake-word/`) — aiohttp WebSocket server running openWakeWord inference on streaming 16-bit PCM audio at 16 kHz. Includes health check, metrics endpoint (detections/hour, audio processed), and configurable threshold/patience/debounce.
- **Browser integration** — AudioWorklet processor for raw PCM capture, `use-wake-word.ts` hook managing WebSocket connection and streaming, three-mode input toggle (push-to-talk → auto → wake-word).
- **State machine** — passive-listening → wake detected → ding → active recording → response → back to passive. Coordinates between wake-word service (Python) and main audio pipeline (Node.js).
- **Docker sidecar** — Added to `docker-compose.yml` with model volume mount and health check.
- **Custom "Coda" model training** — Google Colab notebook (`train_coda_model.ipynb`) using **edge-tts** instead of the broken piper-phonemize dependency. Generates synthetic clips with 300+ Microsoft Edge TTS voices, augments with noise/reverb, trains the DNN classifier.
- **Trained model** — `coda.onnx` (13 KB) included in `models/wake-word/`.

## Architecture

```
PASSIVE MODE:
  Browser AudioWorklet (16kHz PCM) → WebSocket → Python service (port 9000)
    → openWakeWord predict() → wake event → Browser plays ding

ACTIVE MODE (unchanged):
  Browser MediaRecorder → WebSocket → Node.js (port 4000)
    → Whisper STT → Claude → TTS → audio back
```

## Files Changed

| Area | Files |
|------|-------|
| Wake-word service | `services/wake-word/wake_word_service.py`, `Dockerfile`, `requirements.txt` |
| Browser hooks | `use-wake-word.ts`, `pcm-capture-processor.js` |
| UI updates | `mic-button.tsx`, `phase-labels.ts`, `home.tsx`, `use-audio-socket.ts` |
| Config | `router.ts`, `root.tsx`, `.env.example`, `docker-compose.yml`, `.gitignore` |
| Training | `train_coda_model.ipynb`, `generate_clips.py`, `coda_model.yml` |

## Testing

- `pnpm typecheck` — 5/5 packages pass
- `pnpm lint` — 8/8 tasks pass
- Wake-word service: `docker compose up wake-word` or `pip install -r services/wake-word/requirements.txt && python services/wake-word/wake_word_service.py`